### PR TITLE
fix(macos): support command shortcuts and app bundle

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,6 +65,8 @@ jobs:
             args: ""
           - platform: windows-latest
             args: ""
+          - platform: macos-latest
+            args: ""
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ graph LR
 ```
 
 1. **Load Images**: Load PNG, JPG, JPEG, or BMP files.
-2. **Place Marks**: Hold `Ctrl` and click four points to form a rect around your target texture.
+2. **Place Marks**: Hold `Cmd` on macOS or `Ctrl` on Windows/Linux and click four points to form a rect around your target texture.
 3. **Extract**: Hit `Shift + R` or click the Convert button.
 4. **Export**: Position the extracted textures on the Atlas Canvas and export!
 
@@ -57,7 +57,7 @@ Textract is designed for speed. Below is a cheat sheet of shortcuts:
 | **Pan Canvas**   | `Scroll wheel click + Drag` or `Drag Stage` |
 | **Zoom Stage**   | `Scroll Wheel`                              |
 | **Context Menu** | `Right Click`                               |
-| **Select All**   | `Ctrl + A`                                  |
+| **Select All**   | `Cmd + A` on macOS, `Ctrl + A` elsewhere   |
 | **Delete Image** | `Delete` (with image selected)              |
 
 ### Mark Canvas (Left Panel)
@@ -65,7 +65,7 @@ Textract is designed for speed. Below is a cheat sheet of shortcuts:
 | Action                    | Key / Shortcut                 |
 | :------------------------ | :----------------------------- |
 | **Load Images**           | `Shift + A`                    |
-| **Add Mark Point**        | `Ctrl + Left Click` (on image) |
+| **Add Mark Point**        | `Cmd + Left Click` on macOS, `Ctrl + Left Click` elsewhere |
 | **Reset Point Selection** | `Right Click` (while marking)  |
 | **Process/Convert**       | `Shift + R`                    |
 | **Remove Mark**           | `Alt + Left Click` (on mark)   |
@@ -74,8 +74,8 @@ Textract is designed for speed. Below is a cheat sheet of shortcuts:
 
 | Action              | Key / Shortcut |
 | :------------------ | :------------- |
-| **Export Atlas**    | `Ctrl + E`     |
-| **Export Selected** | `Ctrl + S`     |
+| **Export Atlas**    | `Cmd + E` on macOS, `Ctrl + E` elsewhere |
+| **Export Selected** | `Cmd + S` on macOS, `Ctrl + S` elsewhere |
 
 ## 🛠️ Stack
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -39,7 +39,8 @@
     "targets": [
       "nsis",
       "deb",
-      "appimage"
+      "appimage",
+      "app"
     ],
     "icon": [
       "icons/32x32.png",

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,6 @@
+{
+  "bundle": {
+    "targets": ["app"],
+    "createUpdaterArtifacts": false
+  }
+}

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,6 +1,0 @@
-{
-  "bundle": {
-    "targets": ["app"],
-    "createUpdaterArtifacts": false
-  }
-}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,11 +3,12 @@ import Footer from "./components/footer/Footer";
 import Navbar from "./components/Navbar";
 import Textract from "./components/Textract";
 import useAutoUpdater from "./hooks/use-auto-updater";
+import { isShortcutModifierPressed } from "./utils/utils";
 import "./app.css";
 
 function App() {
   document.addEventListener("keydown", (e) => {
-    if (e.ctrlKey && e.code === "KeyA")
+    if (isShortcutModifierPressed(e) && e.code === "KeyA")
       e.preventDefault();
   });
 

--- a/src/components/canvas/Canvas.tsx
+++ b/src/components/canvas/Canvas.tsx
@@ -13,6 +13,7 @@ import useCanvasZoom from "@/components/canvas/hooks/use-canvas-zoom";
 import { useCanvasStore } from "@/stores/canvas-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { CanvasType } from "@/types/types";
+import { isShortcutModifierPressed } from "@/utils/utils";
 import PopupConfirm from "../PopupConfirm";
 import { ContextMenu, ContextMenuContent, ContextMenuGroup, ContextMenuItem, ContextMenuSeparator, ContextMenuShortcut, ContextMenuTrigger } from "../ui/ContextMenu";
 import useCanvasPanning from "./hooks/use-canvas-panning";
@@ -61,7 +62,7 @@ function Canvas({ canvasType, onDelete, transformerRef, contextMenu, children, c
         confirmImageDelete();
         break;
       case "KeyA":
-        if (e.ctrlKey)
+        if (isShortcutModifierPressed(e))
           selectAll();
         break;
       default:

--- a/src/components/canvas/atlas/AtlasCanvas.tsx
+++ b/src/components/canvas/atlas/AtlasCanvas.tsx
@@ -14,6 +14,7 @@ import { ContextMenuCheckboxItem, ContextMenuGroup, ContextMenuItem, ContextMenu
 import { useAtlasStore } from "@/stores/atlas-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { CanvasType } from "@/types/types";
+import { getShortcutModifierLabel, isShortcutModifierPressed } from "@/utils/utils";
 import Canvas from "../Canvas";
 import AtlasImageComponent from "./AtlasImage";
 
@@ -24,6 +25,7 @@ function AtlasCanvas({ className }: { className?: string }) {
 
   const masterGroupRef = useRef<Konva.Group>(null);
   const transformerRef = useRef<Konva.Transformer>(null);
+  const shortcutModifier = getShortcutModifierLabel();
 
   const exportCanvas = async () => {
     const exportPath = await save({
@@ -132,7 +134,8 @@ function AtlasCanvas({ className }: { className?: string }) {
         Export Atlas
         <ContextMenuShortcut>
           <span className="flex">
-            Ctrl+E
+            {shortcutModifier}
+            +E
           </span>
         </ContextMenuShortcut>
       </ContextMenuItem>
@@ -142,7 +145,8 @@ function AtlasCanvas({ className }: { className?: string }) {
         Export Selected
         <ContextMenuShortcut>
           <span className="flex">
-            Ctrl+S
+            {shortcutModifier}
+            +S
           </span>
         </ContextMenuShortcut>
       </ContextMenuItem>
@@ -157,11 +161,11 @@ function AtlasCanvas({ className }: { className?: string }) {
   const handleShortcuts = async (e: React.KeyboardEvent<HTMLDivElement>) => {
     switch (e.code) {
       case "KeyE":
-        if (e.ctrlKey)
+        if (isShortcutModifierPressed(e))
           exportCanvas();
         break;
       case "KeyS":
-        if (e.ctrlKey)
+        if (isShortcutModifierPressed(e))
           exportSelected();
         break;
       default:
@@ -228,8 +232,8 @@ function AtlasCanvas({ className }: { className?: string }) {
       </Canvas>
 
       <Toolbar>
-        <ToolbarAction Icon={BiSolidImageAlt} onClick={exportCanvas} tooltip="Export Atlas (Ctrl+E)" />
-        <ToolbarAction Icon={PiSelection} onClick={exportSelected} tooltip="Export Selected (Ctrl+S)" />
+        <ToolbarAction Icon={BiSolidImageAlt} onClick={exportCanvas} tooltip={`Export Atlas (${shortcutModifier}+E)`} />
+        <ToolbarAction Icon={PiSelection} onClick={exportSelected} tooltip={`Export Selected (${shortcutModifier}+S)`} />
       </Toolbar>
     </div>
   );

--- a/src/components/canvas/mark/MarkImage.tsx
+++ b/src/components/canvas/mark/MarkImage.tsx
@@ -8,7 +8,7 @@ import useImage from "use-image";
 import { useShallow } from "zustand/react/shallow";
 import { useMarkStore } from "@/stores/mark-store";
 import { Colors } from "@/types/types";
-import { getMiddle } from "@/utils/utils";
+import { getMiddle, isShortcutModifierPressed } from "@/utils/utils";
 import Mark from "./Mark";
 import MarkPoint from "./MarkPoint";
 
@@ -76,7 +76,7 @@ function MarkImageComponent({ imageData }: { imageData: MarkImageType }) {
       onClick={(e) => {
         if (e.evt.button === 2)
           setCurrentPoints([]);
-        if (e.evt.button === 0 && e.evt.ctrlKey)
+        if (e.evt.button === 0 && isShortcutModifierPressed(e.evt))
           addPoint(e);
       }}
       onDragStart={(e) => {

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -1,7 +1,7 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useShallow } from "zustand/react/shallow";
 import { useSettingsStore } from "@/stores/settings-store";
-import { snap as snapFn, snapPowerOfTwo } from "@/utils/utils";
+import { getShortcutModifierLabel, snap as snapFn, snapPowerOfTwo } from "@/utils/utils";
 import { Button } from "../ui/Button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/Tooltip";
 import FooterBooleanSetting from "./FooterBooleanSetting";
@@ -22,6 +22,7 @@ function ShortcutHelper({ shortcut, description }: { shortcut: string; descripti
 }
 
 export default function Footer() {
+  const shortcutModifier = getShortcutModifierLabel();
   const { snap, atlasResolution, atlasAlpha }
     = useSettingsStore(
       useShallow(s => ({
@@ -41,19 +42,19 @@ export default function Footer() {
 
           <TooltipContent className="flex flex-col gap-2">
             <ShortcutHelper shortcut="Shift+A" description="Load Images" />
-            <ShortcutHelper shortcut="Ctrl+A" description="Select All" />
+            <ShortcutHelper shortcut={`${shortcutModifier}+A`} description="Select All" />
             <ShortcutHelper shortcut="Delete" description="Delete Images" />
 
             <hr />
 
-            <ShortcutHelper shortcut="Ctrl+Click" description="Add Mark Point" />
+            <ShortcutHelper shortcut={`${shortcutModifier}+Click`} description="Add Mark Point" />
             <ShortcutHelper shortcut="Shift+R" description="Convert Marks" />
             <ShortcutHelper shortcut="Alt+Click" description="Delete Mark" />
 
             <hr />
 
-            <ShortcutHelper shortcut="Ctrl+E" description="Export Atlas" />
-            <ShortcutHelper shortcut="Ctrl+S" description="Export Selected" />
+            <ShortcutHelper shortcut={`${shortcutModifier}+E`} description="Export Atlas" />
+            <ShortcutHelper shortcut={`${shortcutModifier}+S`} description="Export Selected" />
 
             <hr />
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -7,6 +7,18 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+function isMacOS() {
+  return navigator.platform.toLowerCase().includes("mac");
+}
+
+export function isShortcutModifierPressed(e: Pick<KeyboardEvent | MouseEvent, "ctrlKey" | "metaKey">) {
+  return isMacOS() ? e.metaKey : e.ctrlKey;
+}
+
+export function getShortcutModifierLabel() {
+  return isMacOS() ? "Cmd" : "Ctrl";
+}
+
 export function getMiddle(v: Vec2[]) {
   const average = v.reduce((a, b) => {
     return { x: a.x + b.x, y: a.y + b.y };


### PR DESCRIPTION
## Summary

- add a macOS-specific Tauri config that builds a `.app` bundle and disables updater artifacts
- use Command for modifier shortcuts on macOS while keeping Control on Windows/Linux
- update shortcut labels and README docs to show the correct platform-specific shortcuts

## Why

The default bundle configuration targets Windows and Linux bundle formats, which prevents a minimal macOS `.app` build. macOS also treats Control-click as a right-click/context-menu gesture, so mark placement and related shortcuts need to use Command on macOS without changing the expected Control shortcuts on Windows/Linux.

## Testing

- `npm run lint`
- `npm run build`
- `npm run tauri build -- --bundles app`
- launched the generated `Textract.app` on macOS and confirmed Command-click mark placement works
