### PR TITLE
Add macOS support (bundle target + CI)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,6 +65,8 @@ jobs:
             args: ""
           - platform: windows-latest
             args: ""
+          - platform: macos-latest
+            args: ""
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -53,7 +53,8 @@
     "category": "Utility",
     "shortDescription": "Texture extractor from photos",
     "macOS": {
-      "minimumSystemVersion": "10.15"
+      "minimumSystemVersion": "10.15",
+      "entitlements": "./Entitlements.plist"
     }
   },
   "plugins": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -39,7 +39,9 @@
     "targets": [
       "nsis",
       "deb",
-      "appimage"
+      "appimage",
+      "dmg",
+      "app"
     ],
     "icon": [
       "icons/32x32.png",
@@ -49,7 +51,10 @@
       "icons/icon.ico"
     ],
     "category": "Utility",
-    "shortDescription": "Texture extractor from photos"
+    "shortDescription": "Texture extractor from photos",
+    "macOS": {
+      "minimumSystemVersion": "10.15"
+    }
   },
   "plugins": {
     "updater": {


### PR DESCRIPTION
## Summary
- Adds `dmg` and `app` to `bundle.targets` in `tauri.conf.json`, plus `macOS.minimumSystemVersion: "10.15"`
- Adds `src-tauri/Entitlements.plist` (JIT / unsigned-executable-memory / disabled library validation), required for the app to run correctly under macOS's hardened runtime — wired in via `bundle.macOS.entitlements`
- Adds `macos-latest` to the release workflow's build matrix, unsigned like the existing `ubuntu-22.04`/`windows-latest` jobs

## Why
The app already builds and runs on macOS with **zero changes to the Rust or frontend code** — the backend (`image`/`imageproc`/`rayon`) has no platform-specific code, and Tauri v2 is cross-platform by design. macOS support was simply never wired up in the bundle/CI config. This PR closes that gap.

## Test plan
- [x] `npm run tauri dev` runs natively on macOS (Apple Silicon, macOS 15.7.8) with no code changes
- [x] `npm run tauri build` produces a working `Textract.app` and `Textract_*.dmg`
- [x] Release build launches and renders identically to the dev build (verified visually)
- [x] Signed and notarized locally with a personal Developer ID identity as a further check — `codesign --verify --deep --strict` passes, `spctl -a -vv` accepts the result as "Notarized Developer ID" (this PR itself doesn't add any signing secrets to CI — the macOS CI job builds unsigned, matching the existing Windows job)