### PR TITLE
feat: add curved-surface (grid mark) extraction

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod mesh;
 mod transformation;
 mod utils;
 
@@ -18,7 +19,10 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![transformation::transform_image,])
+        .invoke_handler(tauri::generate_handler![
+            transformation::transform_image,
+            mesh::transform_image_mesh,
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/mesh.rs
+++ b/src-tauri/src/mesh.rs
@@ -1,0 +1,338 @@
+use base64::{engine::general_purpose, Engine};
+use image::{open, Rgba, RgbaImage};
+use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use serde::Deserialize;
+use std::io::Cursor;
+
+/// One curved-surface mark: an `rows` x `cols` grid of source control points,
+/// laid out row-major (row 0 left-to-right, then row 1, ...).
+#[derive(Deserialize)]
+pub struct GridMark {
+    rows: u32,
+    cols: u32,
+    points: Vec<f32>,
+}
+
+#[tauri::command]
+pub async fn transform_image_mesh(
+    img_path: String,
+    marks: Vec<GridMark>,
+) -> Result<Vec<String>, String> {
+    log::info!("Processing {} grid marks for {img_path}", marks.len());
+
+    let img = open(&img_path).map_err(|e| e.to_string())?.to_rgba8();
+    let img_name = crate::utils::get_filename_or_invalid(&img_path);
+
+    let buffers: Result<Vec<String>, String> = marks
+        .par_iter()
+        .enumerate()
+        .map(|(i, mark)| {
+            let result = warp_mesh(&img, mark)?;
+            log::info!("Finished processing grid mark #{} for {}", (i + 1), img_name);
+            image_to_base_64(&result)
+        })
+        .collect();
+
+    log::info!("Finished processing all grid marks for {}", img_name);
+    buffers
+}
+
+fn warp_mesh(img: &RgbaImage, mark: &GridMark) -> Result<RgbaImage, String> {
+    let rows = mark.rows as usize;
+    let cols = mark.cols as usize;
+
+    if rows < 2 || cols < 2 {
+        return Err("Grid mark needs at least a 2x2 grid of points".to_string());
+    }
+    if mark.points.len() != rows * cols * 2 {
+        return Err(format!(
+            "Expected {} point values ({rows}x{cols} grid) but got {}",
+            rows * cols * 2,
+            mark.points.len()
+        ));
+    }
+
+    let src = grid_from_flat(&mark.points, rows, cols);
+    let (cell_w, cell_h) = average_cell_size(&src, rows, cols);
+    let out_width = ((cols - 1) as f32 * cell_w).round().max(1.0) as u32;
+    let out_height = ((rows - 1) as f32 * cell_h).round().max(1.0) as u32;
+
+    let dst = target_grid(rows, cols, cell_w, cell_h);
+
+    let mut out = RgbaImage::new(out_width, out_height);
+
+    for i in 0..rows - 1 {
+        for j in 0..cols - 1 {
+            // Two triangles per grid cell, split along the same diagonal on
+            // both the source and target side so the mapping stays 1:1.
+            let src_tl = src[i][j];
+            let src_tr = src[i][j + 1];
+            let src_bl = src[i + 1][j];
+            let src_br = src[i + 1][j + 1];
+
+            let dst_tl = dst[i][j];
+            let dst_tr = dst[i][j + 1];
+            let dst_bl = dst[i + 1][j];
+            let dst_br = dst[i + 1][j + 1];
+
+            warp_triangle(img, &mut out, (src_tl, src_tr, src_bl), (dst_tl, dst_tr, dst_bl));
+            warp_triangle(img, &mut out, (src_br, src_bl, src_tr), (dst_br, dst_bl, dst_tr));
+        }
+    }
+
+    Ok(out)
+}
+
+fn grid_from_flat(points: &[f32], rows: usize, cols: usize) -> Vec<Vec<(f32, f32)>> {
+    let mut grid = Vec::with_capacity(rows);
+    for i in 0..rows {
+        let mut row = Vec::with_capacity(cols);
+        for j in 0..cols {
+            let idx = (i * cols + j) * 2;
+            row.push((points[idx], points[idx + 1]));
+        }
+        grid.push(row);
+    }
+    grid
+}
+
+/// Average horizontal/vertical spacing across the source grid, used as the
+/// uniform cell size for the flattened output grid.
+fn average_cell_size(src: &[Vec<(f32, f32)>], rows: usize, cols: usize) -> (f32, f32) {
+    let dist = |a: (f32, f32), b: (f32, f32)| ((a.0 - b.0).powi(2) + (a.1 - b.1).powi(2)).sqrt();
+
+    let mut width_sum: f32 = 0.0;
+    let mut width_count: f32 = 0.0;
+    for row in src.iter().take(rows) {
+        for j in 0..cols - 1 {
+            width_sum += dist(row[j], row[j + 1]);
+            width_count += 1.0;
+        }
+    }
+
+    let mut height_sum: f32 = 0.0;
+    let mut height_count: f32 = 0.0;
+    for j in 0..cols {
+        for i in 0..rows - 1 {
+            height_sum += dist(src[i][j], src[i + 1][j]);
+            height_count += 1.0;
+        }
+    }
+
+    (
+        (width_sum / width_count.max(1.0)).max(1.0),
+        (height_sum / height_count.max(1.0)).max(1.0),
+    )
+}
+
+fn target_grid(rows: usize, cols: usize, cell_w: f32, cell_h: f32) -> Vec<Vec<(f32, f32)>> {
+    (0..rows)
+        .map(|i| {
+            (0..cols)
+                .map(|j| (j as f32 * cell_w, i as f32 * cell_h))
+                .collect()
+        })
+        .collect()
+}
+
+/// Backward-maps every destination pixel inside the target triangle to its
+/// source-triangle location via barycentric coordinates, then bilinear-samples
+/// the source image. Iterating destination pixels (rather than pushing source
+/// pixels forward) is what guarantees no gaps/cracks between triangles.
+fn warp_triangle(
+    src_img: &RgbaImage,
+    out: &mut RgbaImage,
+    src_tri: ((f32, f32), (f32, f32), (f32, f32)),
+    dst_tri: ((f32, f32), (f32, f32), (f32, f32)),
+) {
+    let (out_w, out_h) = out.dimensions();
+    let (d0, d1, d2) = dst_tri;
+
+    let min_x = d0.0.min(d1.0).min(d2.0).floor().max(0.0) as u32;
+    let max_x = d0.0.max(d1.0).max(d2.0).ceil().min(out_w as f32 - 1.0) as u32;
+    let min_y = d0.1.min(d1.1).min(d2.1).floor().max(0.0) as u32;
+    let max_y = d0.1.max(d1.1).max(d2.1).ceil().min(out_h as f32 - 1.0) as u32;
+
+    if max_x < min_x || max_y < min_y {
+        return;
+    }
+
+    let (s0, s1, s2) = src_tri;
+
+    for y in min_y..=max_y {
+        for x in min_x..=max_x {
+            // Index-space, not pixel-center — matches imageproc's own
+            // warp_inner/interpolate_bilinear convention (see transformation.rs),
+            // so a flat/no-op mesh warp doesn't introduce a half-pixel shift.
+            let p = (x as f32, y as f32);
+            if let Some((a, b, c)) = barycentric(p, d0, d1, d2) {
+                if inside_triangle((a, b, c)) {
+                    let src_x = a * s0.0 + b * s1.0 + c * s2.0;
+                    let src_y = a * s0.1 + b * s1.1 + c * s2.1;
+                    let pixel = sample_bilinear(src_img, src_x, src_y);
+                    out.put_pixel(x, y, pixel);
+                }
+            }
+        }
+    }
+}
+
+fn barycentric(
+    p: (f32, f32),
+    a: (f32, f32),
+    b: (f32, f32),
+    c: (f32, f32),
+) -> Option<(f32, f32, f32)> {
+    let denom = (b.1 - c.1) * (a.0 - c.0) + (c.0 - b.0) * (a.1 - c.1);
+    if denom.abs() < 1e-6 {
+        return None;
+    }
+    let alpha = ((b.1 - c.1) * (p.0 - c.0) + (c.0 - b.0) * (p.1 - c.1)) / denom;
+    let beta = ((c.1 - a.1) * (p.0 - c.0) + (a.0 - c.0) * (p.1 - c.1)) / denom;
+    let gamma = 1.0 - alpha - beta;
+    Some((alpha, beta, gamma))
+}
+
+fn inside_triangle(bary: (f32, f32, f32)) -> bool {
+    // A small negative tolerance keeps shared triangle edges filled on both
+    // sides instead of leaving a hairline gap due to float rounding.
+    const EPS: f32 = -1e-3;
+    bary.0 >= EPS && bary.1 >= EPS && bary.2 >= EPS
+}
+
+fn sample_bilinear(img: &RgbaImage, x: f32, y: f32) -> Rgba<u8> {
+    let (w, h) = img.dimensions();
+    if w == 0 || h == 0 || x < 0.0 || y < 0.0 || x > (w - 1) as f32 || y > (h - 1) as f32 {
+        return Rgba([0, 0, 0, 0]);
+    }
+
+    let x0 = x.floor() as u32;
+    let y0 = y.floor() as u32;
+    let x1 = (x0 + 1).min(w - 1);
+    let y1 = (y0 + 1).min(h - 1);
+    let fx = x - x0 as f32;
+    let fy = y - y0 as f32;
+
+    let p00 = img.get_pixel(x0, y0).0;
+    let p10 = img.get_pixel(x1, y0).0;
+    let p01 = img.get_pixel(x0, y1).0;
+    let p11 = img.get_pixel(x1, y1).0;
+
+    let mut out = [0u8; 4];
+    for ch in 0..4 {
+        let top = p00[ch] as f32 * (1.0 - fx) + p10[ch] as f32 * fx;
+        let bottom = p01[ch] as f32 * (1.0 - fx) + p11[ch] as f32 * fx;
+        out[ch] = (top * (1.0 - fy) + bottom * fy).round() as u8;
+    }
+    Rgba(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Source image where each pixel encodes its own coordinates in R/G, so
+    /// warp correctness can be checked by comparing output color back to the
+    /// expected source (x, y) rather than eyeballing an image.
+    fn coordinate_image(w: u32, h: u32) -> RgbaImage {
+        RgbaImage::from_fn(w, h, |x, y| Rgba([x as u8, y as u8, 100, 255]))
+    }
+
+    #[test]
+    fn flat_grid_matches_a_plain_crop() {
+        let img = coordinate_image(100, 60);
+        // A perfectly rectangular 3x3 grid over [10,10]..[90,50] has no
+        // actual curvature, so it should behave like extracting that crop.
+        let mut points = Vec::new();
+        for i in 0..3 {
+            for j in 0..3 {
+                points.push(10.0 + j as f32 * 40.0);
+                points.push(10.0 + i as f32 * 20.0);
+            }
+        }
+        let mark = GridMark {
+            rows: 3,
+            cols: 3,
+            points,
+        };
+
+        let out = warp_mesh(&img, &mark).expect("warp should succeed");
+        assert_eq!(out.dimensions(), (80, 40));
+
+        // Top-left corner of the crop should sample back near source (10, 10).
+        let corner = out.get_pixel(0, 0);
+        assert!((corner[0] as i32 - 10).abs() <= 1, "unexpected R at corner: {corner:?}");
+        assert!((corner[1] as i32 - 10).abs() <= 1, "unexpected G at corner: {corner:?}");
+
+        // Bottom-right corner should sample back near source (90, 50).
+        let corner = out.get_pixel(79, 39);
+        assert!((corner[0] as i32 - 90).abs() <= 1, "unexpected R at br corner: {corner:?}");
+        assert!((corner[1] as i32 - 50).abs() <= 1, "unexpected G at br corner: {corner:?}");
+
+        // Center of the crop should sample back near source (50, 30).
+        let center = out.get_pixel(40, 20);
+        assert!((center[0] as i32 - 50).abs() <= 1, "unexpected R at center: {center:?}");
+        assert!((center[1] as i32 - 30).abs() <= 1, "unexpected G at center: {center:?}");
+    }
+
+    #[test]
+    fn curved_grid_bows_the_middle_row_outward() {
+        let img = coordinate_image(100, 100);
+        // Middle row bows downward (curved surface), top/bottom rows stay straight.
+        let mut points = Vec::new();
+        for i in 0..3u32 {
+            for j in 0..3u32 {
+                let x = 10.0 + j as f32 * 40.0;
+                let bow = if i == 1 { 15.0 } else { 0.0 };
+                let y = 10.0 + i as f32 * 40.0 + bow;
+                points.push(x);
+                points.push(y);
+            }
+        }
+        let mark = GridMark {
+            rows: 3,
+            cols: 3,
+            points,
+        };
+
+        let out = warp_mesh(&img, &mark).expect("warp should succeed");
+        // Output is still a flat rectangle despite the curved input mesh.
+        // Row spacing averages back to 40 (10->65 then 65->90 -> mean 40),
+        // same as the unbowed case, since the output uses a uniform target grid.
+        assert_eq!(out.dimensions(), (80, 80));
+    }
+
+    #[test]
+    fn rejects_mismatched_point_count() {
+        let mark = GridMark {
+            rows: 3,
+            cols: 3,
+            points: vec![0.0, 0.0, 1.0, 1.0], // way too few for a 3x3 grid
+        };
+        let img = coordinate_image(10, 10);
+        assert!(warp_mesh(&img, &mark).is_err());
+    }
+
+    #[test]
+    fn rejects_grid_smaller_than_2x2() {
+        let mark = GridMark {
+            rows: 1,
+            cols: 3,
+            points: vec![0.0, 0.0, 1.0, 0.0, 2.0, 0.0],
+        };
+        let img = coordinate_image(10, 10);
+        assert!(warp_mesh(&img, &mark).is_err());
+    }
+}
+
+fn image_to_base_64(image: &RgbaImage) -> Result<String, String> {
+    let mut buffer: Vec<u8> = Vec::new();
+    image
+        .write_to(&mut Cursor::new(&mut buffer), image::ImageFormat::Png)
+        .map_err(|e| e.to_string())?;
+
+    Ok(format!(
+        "data:image/png;base64,{}",
+        general_purpose::STANDARD.encode(buffer)
+    ))
+}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -24,8 +24,12 @@ export function ToolbarAction({ Icon, onClick, disabled = false, active, tooltip
     <Tooltip delayDuration={400}>
       <TooltipTrigger asChild>
         <Icon
+          // `!opacity-*`/`!text-*` (Tailwind's important-modifier) are required here:
+          // .button-icon already bakes in its own opacity-50/hover:opacity-100, which
+          // otherwise wins the cascade over a plain (non-important) utility and made
+          // the active/inactive states barely distinguishable.
           className={`size-${size} ${disabled ? "opacity-20 pointer-events-none" : "button-icon"
-          } ${isToggle ? (active ? "text-primary" : "opacity-40") : ""}`}
+          } ${isToggle ? (active ? "!opacity-100 !text-primary" : "!opacity-30") : ""}`}
           onClick={disabled ? undefined : onClick}
         />
       </TooltipTrigger>

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -6,18 +6,26 @@ type ToolbarActionProps = {
   size?: number;
   tooltip?: string;
   disabled?: boolean;
-  /** Visually highlights the action, e.g. for a toggled-on mode. */
+  /**
+   * Marks this action as a stateful toggle (e.g. a mode switch), not a
+   * momentary action like Load/Convert. Pass `true`/`false` for its current
+   * state — when active it's highlighted, when inactive it's dimmed rather
+   * than shown at full brightness, so a group of mode toggles makes the
+   * current mode visually obvious. Omit entirely for plain action buttons.
+   */
   active?: boolean;
   onClick?: () => void | Promise<void>;
 };
 
-export function ToolbarAction({ Icon, onClick, disabled = false, active = false, tooltip, size = 6 }: ToolbarActionProps) {
+export function ToolbarAction({ Icon, onClick, disabled = false, active, tooltip, size = 6 }: ToolbarActionProps) {
+  const isToggle = active !== undefined;
+
   return (
     <Tooltip delayDuration={400}>
       <TooltipTrigger asChild>
         <Icon
           className={`size-${size} ${disabled ? "opacity-20 pointer-events-none" : "button-icon"
-          } ${active ? "text-primary" : ""}`}
+          } ${isToggle ? (active ? "text-primary" : "opacity-40") : ""}`}
           onClick={disabled ? undefined : onClick}
         />
       </TooltipTrigger>

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -6,16 +6,18 @@ type ToolbarActionProps = {
   size?: number;
   tooltip?: string;
   disabled?: boolean;
+  /** Visually highlights the action, e.g. for a toggled-on mode. */
+  active?: boolean;
   onClick?: () => void | Promise<void>;
 };
 
-export function ToolbarAction({ Icon, onClick, disabled = false, tooltip, size = 6 }: ToolbarActionProps) {
+export function ToolbarAction({ Icon, onClick, disabled = false, active = false, tooltip, size = 6 }: ToolbarActionProps) {
   return (
     <Tooltip delayDuration={400}>
       <TooltipTrigger asChild>
         <Icon
           className={`size-${size} ${disabled ? "opacity-20 pointer-events-none" : "button-icon"
-          }`}
+          } ${active ? "text-primary" : ""}`}
           onClick={disabled ? undefined : onClick}
         />
       </TooltipTrigger>

--- a/src/components/canvas/mark/Mark.tsx
+++ b/src/components/canvas/mark/Mark.tsx
@@ -102,7 +102,7 @@ function Mark({ mark, scale = 1 }: { mark: MarkType; scale?: number }) {
 
       {gridLines.map((linePoints, idx) => (
         // eslint-disable-next-line react/no-array-index-key
-        <Line key={idx} offset={{ x: -markOffset.x, y: -markOffset.y }} points={linePoints} stroke="white" opacity={0.5} strokeWidth={scale} />
+        <Line key={idx} offset={{ x: -markOffset.x, y: -markOffset.y }} points={linePoints} stroke="white" opacity={0.5} strokeWidth={scale} listening={false} />
       ))}
 
       {points.map((p, id) => {

--- a/src/components/canvas/mark/Mark.tsx
+++ b/src/components/canvas/mark/Mark.tsx
@@ -9,16 +9,52 @@ import MarkPoint from "./MarkPoint";
 function Mark({ mark, scale = 1 }: { mark: MarkType; scale?: number }) {
   const [markOffset, setMarkOffset] = useState({ x: 0, y: 0 });
   const [points, setPoints] = useState(mark.points);
-  const pointsFlat = useMemo(() => points.flatMap(p => [p.x, p.y]), [points]);
+  const isGrid = mark.markType === "grid" && !!mark.gridDims;
+  const { rows, cols } = mark.gridDims ?? { rows: 0, cols: 0 };
 
-  const gridPoints = useMemo(() => {
-    const gridLineY1 = { p1: lerpVec2(points[0], points[1], 0.33), p2: lerpVec2(points[3], points[2], 0.33) };
-    const gridLineY2 = { p1: lerpVec2(points[0], points[1], 0.67), p2: lerpVec2(points[3], points[2], 0.67) };
-    const gridLineX1 = { p1: lerpVec2(points[0], points[3], 0.33), p2: lerpVec2(points[1], points[2], 0.33) };
-    const gridLineX2 = { p1: lerpVec2(points[0], points[3], 0.67), p2: lerpVec2(points[1], points[2], 0.67) };
+  // A grid mark's points are row-major, so a single closed Line through them
+  // in that order would zigzag — walk the perimeter (top row, right column,
+  // bottom row reversed, left column reversed) for the outline shape instead.
+  const outlinePoints = useMemo(() => {
+    if (!isGrid)
+      return points;
 
-    return { lines: [gridLineY1, gridLineY2, gridLineX1, gridLineX2] };
-  }, [points]);
+    const at = (r: number, c: number) => points[r * cols + c];
+    const perimeter: typeof points = [];
+    for (let c = 0; c < cols; c++) perimeter.push(at(0, c));
+    for (let r = 1; r < rows; r++) perimeter.push(at(r, cols - 1));
+    for (let c = cols - 2; c >= 0; c--) perimeter.push(at(rows - 1, c));
+    for (let r = rows - 2; r >= 1; r--) perimeter.push(at(r, 0));
+    return perimeter;
+  }, [isGrid, points, rows, cols]);
+
+  const pointsFlat = useMemo(() => outlinePoints.flatMap(p => [p.x, p.y]), [outlinePoints]);
+
+  // Each entry is a flattened [x,y,x,y,...] polyline. For grid marks these
+  // walk every intermediate point (not just the two ends) so the preview
+  // line actually follows the curve the user has dragged into shape rather
+  // than showing a straight chord across it.
+  const gridLines: number[][] = useMemo(() => {
+    if (isGrid) {
+      const lines: number[][] = [];
+      for (let r = 0; r < rows; r++) {
+        const row = points.slice(r * cols, r * cols + cols);
+        lines.push(row.flatMap(p => [p.x, p.y]));
+      }
+      for (let c = 0; c < cols; c++) {
+        const col = Array.from({ length: rows }, (_, r) => points[r * cols + c]);
+        lines.push(col.flatMap(p => [p.x, p.y]));
+      }
+      return lines;
+    }
+
+    const gridLineY1 = [lerpVec2(points[0], points[1], 0.33), lerpVec2(points[3], points[2], 0.33)];
+    const gridLineY2 = [lerpVec2(points[0], points[1], 0.67), lerpVec2(points[3], points[2], 0.67)];
+    const gridLineX1 = [lerpVec2(points[0], points[3], 0.33), lerpVec2(points[1], points[2], 0.33)];
+    const gridLineX2 = [lerpVec2(points[0], points[3], 0.67), lerpVec2(points[1], points[2], 0.67)];
+
+    return [gridLineY1, gridLineY2, gridLineX1, gridLineX2].map(line => line.flatMap(p => [p.x, p.y]));
+  }, [isGrid, points, rows, cols]);
 
   return (
     <Group draggable>
@@ -64,9 +100,9 @@ function Mark({ mark, scale = 1 }: { mark: MarkType; scale?: number }) {
         }}
       />
 
-      {gridPoints.lines.map((line, idx) => (
+      {gridLines.map((linePoints, idx) => (
         // eslint-disable-next-line react/no-array-index-key
-        <Line key={idx} offset={{ x: -markOffset.x, y: -markOffset.y }} points={[line.p1.x, line.p1.y, line.p2.x, line.p2.y]} stroke="white" opacity={0.5} strokeWidth={scale} />
+        <Line key={idx} offset={{ x: -markOffset.x, y: -markOffset.y }} points={linePoints} stroke="white" opacity={0.5} strokeWidth={scale} />
       ))}
 
       {points.map((p, id) => {

--- a/src/components/canvas/mark/MarkCanvas.tsx
+++ b/src/components/canvas/mark/MarkCanvas.tsx
@@ -6,7 +6,7 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { exists } from "@tauri-apps/plugin-fs";
 import { info, warn } from "@tauri-apps/plugin-log";
 import Konva from "konva";
-import { TrashIcon } from "lucide-react";
+import { Grid3x3, TrashIcon } from "lucide-react";
 import { useEffect, useRef } from "react";
 import { CgAdd } from "react-icons/cg";
 import { FaPlay } from "react-icons/fa";
@@ -28,6 +28,7 @@ function MarkCanvas({ className = "" }: { className?: string }) {
   const atlasImages = useAtlasStore(state => state.images);
   const selectedNodes = useCanvasStore(s => s.transientCanvas[CanvasType.MARK].selectedNodes);
   const hoverShape = useCanvasStore(s => s.transientCanvas[CanvasType.MARK].hoverShape);
+  const markCreationMode = useCanvasStore(s => s.transientCanvas[CanvasType.MARK].markCreationMode);
   const snapSize = useSettingsStore(s => s.snap);
 
   const transformerRef = useRef<Konva.Transformer>(null);
@@ -168,43 +169,67 @@ function MarkCanvas({ className = "" }: { className?: string }) {
           return;
         }
 
-        const markPoints = dirtyIds.flatMap(id =>
-          marks[id].points.flatMap(p => [Math.round(p.x), Math.round(p.y)]),
-        );
+        const applyResults = async (ids: string[], results: string[]) => {
+          results.forEach(async (base64, idx) => {
+            const markId = ids[idx];
+            const existingAtlasImage = Object.values(atlasImages).find(image => image.markId === markId);
 
-        const results: string[] = await invoke("transform_image", {
-          imgPath: image.filepath,
-          points: markPoints,
-        });
+            const img = new Image();
+            img.src = base64;
+            await img.decode();
+            const snapScaleX = snap(img.width, snapSize) / img.width;
+            const snapScaleY = snap(img.height, snapSize) / img.height;
 
-        results.forEach(async (base64, idx) => {
-          const markId = dirtyIds[idx];
-          const existingAtlasImage = Object.values(atlasImages).find(image => image.markId === markId);
+            if (existingAtlasImage) {
+              useAtlasStore.getState().updateImageBase64(existingAtlasImage.id, base64);
+              useAtlasStore.getState().updateImageScale(existingAtlasImage.id, { x: snapScaleX, y: snapScaleY });
+            }
+            else {
+              const atlasImage: AtlasImageType = {
+                id: crypto.randomUUID(),
+                base64,
+                markId,
+                position: { x: 0, y: 0 },
+                rotation: 0,
+                scale: { x: snapScaleX, y: snapScaleY },
+              };
 
-          const img = new Image();
-          img.src = base64;
-          await img.decode();
-          const snapScaleX = snap(img.width, snapSize) / img.width;
-          const snapScaleY = snap(img.height, snapSize) / img.height;
+              useAtlasStore.getState().addImage(atlasImage);
+            }
+            useMarkStore.getState().updateMarkDirty(markId, false);
+          });
+        };
 
-          if (existingAtlasImage) {
-            useAtlasStore.getState().updateImageBase64(existingAtlasImage.id, base64);
-            useAtlasStore.getState().updateImageScale(existingAtlasImage.id, { x: snapScaleX, y: snapScaleY });
-          }
-          else {
-            const atlasImage: AtlasImageType = {
-              id: crypto.randomUUID(),
-              base64,
-              markId,
-              position: { x: 0, y: 0 },
-              rotation: 0,
-              scale: { x: snapScaleX, y: snapScaleY },
-            };
+        const quadIds = dirtyIds.filter(id => marks[id].markType !== "grid");
+        const gridIds = dirtyIds.filter(id => marks[id].markType === "grid");
 
-            useAtlasStore.getState().addImage(atlasImage);
-          }
-          useMarkStore.getState().updateMarkDirty(markId, false);
-        });
+        if (quadIds.length > 0) {
+          const markPoints = quadIds.flatMap(id =>
+            marks[id].points.flatMap(p => [Math.round(p.x), Math.round(p.y)]),
+          );
+
+          const results: string[] = await invoke("transform_image", {
+            imgPath: image.filepath,
+            points: markPoints,
+          });
+
+          await applyResults(quadIds, results);
+        }
+
+        if (gridIds.length > 0) {
+          const gridMarks = gridIds.map(id => ({
+            rows: marks[id].gridDims!.rows,
+            cols: marks[id].gridDims!.cols,
+            points: marks[id].points.flatMap(p => [Math.round(p.x), Math.round(p.y)]),
+          }));
+
+          const results: string[] = await invoke("transform_image_mesh", {
+            imgPath: image.filepath,
+            marks: gridMarks,
+          });
+
+          await applyResults(gridIds, results);
+        }
 
         toast.success(`Finished processing ${dirtyIds.length} marks for ${imgName}`);
         info(`Finished processing ${dirtyIds.length} marks for ${imgName}`);
@@ -297,6 +322,10 @@ function MarkCanvas({ className = "" }: { className?: string }) {
         if (e.shiftKey)
           convertMarks();
         break;
+      case "KeyG":
+        if (e.shiftKey)
+          useCanvasStore.getState().toggleMarkCreationMode(CanvasType.MARK);
+        break;
       default:
         break;
     }
@@ -323,6 +352,15 @@ function MarkCanvas({ className = "" }: { className?: string }) {
       <Toolbar>
         <ToolbarAction Icon={CgAdd} onClick={loadImages} tooltip="Load Images (Shift+A)" />
         <ToolbarAction Icon={FaPlay} size={4} onClick={() => convertMarks()} tooltip="Convert Marks (Shift+R)" />
+        <ToolbarAction
+          Icon={Grid3x3}
+          size={4}
+          active={markCreationMode === "grid"}
+          onClick={() => useCanvasStore.getState().toggleMarkCreationMode(CanvasType.MARK)}
+          tooltip={markCreationMode === "grid"
+            ? "Grid mode: Ctrl+Click 4 corners to place a curved-surface mark (Shift+G)"
+            : "Quad mode: Ctrl+Click 4 corners for a straight mark (Shift+G to switch to curved/grid mode)"}
+        />
       </Toolbar>
     </div>
   );

--- a/src/components/canvas/mark/MarkCanvas.tsx
+++ b/src/components/canvas/mark/MarkCanvas.tsx
@@ -6,7 +6,7 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { exists } from "@tauri-apps/plugin-fs";
 import { error, info, warn } from "@tauri-apps/plugin-log";
 import Konva from "konva";
-import { Grid3x3, TrashIcon } from "lucide-react";
+import { BoxSelect, Grid3x3, TrashIcon } from "lucide-react";
 import { useEffect, useRef } from "react";
 import { CgAdd } from "react-icons/cg";
 import { FaPlay } from "react-icons/fa";
@@ -362,13 +362,18 @@ function MarkCanvas({ className = "" }: { className?: string }) {
         <ToolbarAction Icon={CgAdd} onClick={loadImages} tooltip="Load Images (Shift+A)" />
         <ToolbarAction Icon={FaPlay} size={4} onClick={() => convertMarks()} tooltip="Convert Marks (Shift+R)" />
         <ToolbarAction
+          Icon={BoxSelect}
+          size={4}
+          active={markCreationMode === "quad"}
+          onClick={() => useCanvasStore.getState().setMarkCreationMode(CanvasType.MARK, "quad")}
+          tooltip={`Quad mode: ${getShortcutModifierLabel()}+Click 4 corners for a straight mark (Shift+G to switch)`}
+        />
+        <ToolbarAction
           Icon={Grid3x3}
           size={4}
           active={markCreationMode === "grid"}
-          onClick={() => useCanvasStore.getState().toggleMarkCreationMode(CanvasType.MARK)}
-          tooltip={markCreationMode === "grid"
-            ? `Grid mode: ${getShortcutModifierLabel()}+Click 4 corners to place a curved-surface mark (Shift+G)`
-            : `Quad mode: ${getShortcutModifierLabel()}+Click 4 corners for a straight mark (Shift+G to switch to curved/grid mode)`}
+          onClick={() => useCanvasStore.getState().setMarkCreationMode(CanvasType.MARK, "grid")}
+          tooltip={`Grid mode: ${getShortcutModifierLabel()}+Click 4 corners to place a curved-surface mark (Shift+G to switch)`}
         />
 
         {markCreationMode === "grid" && (

--- a/src/components/canvas/mark/MarkCanvas.tsx
+++ b/src/components/canvas/mark/MarkCanvas.tsx
@@ -12,6 +12,7 @@ import { CgAdd } from "react-icons/cg";
 import { FaPlay } from "react-icons/fa";
 import { Line } from "react-konva";
 import { toast } from "sonner";
+import FooterNumberSetting from "@/components/footer/FooterNumberSetting";
 import { Toolbar, ToolbarAction } from "@/components/Toolbar";
 import { ContextMenuGroup, ContextMenuItem, ContextMenuSeparator, ContextMenuShortcut, ContextMenuSub, ContextMenuSubContent, ContextMenuSubTrigger } from "@/components/ui/ContextMenu";
 import { useAtlasStore } from "@/stores/atlas-store";
@@ -29,6 +30,8 @@ function MarkCanvas({ className = "" }: { className?: string }) {
   const selectedNodes = useCanvasStore(s => s.transientCanvas[CanvasType.MARK].selectedNodes);
   const hoverShape = useCanvasStore(s => s.transientCanvas[CanvasType.MARK].hoverShape);
   const markCreationMode = useCanvasStore(s => s.transientCanvas[CanvasType.MARK].markCreationMode);
+  const markGridRows = useCanvasStore(s => s.transientCanvas[CanvasType.MARK].markGridRows);
+  const markGridCols = useCanvasStore(s => s.transientCanvas[CanvasType.MARK].markGridCols);
   const snapSize = useSettingsStore(s => s.snap);
 
   const transformerRef = useRef<Konva.Transformer>(null);
@@ -361,6 +364,27 @@ function MarkCanvas({ className = "" }: { className?: string }) {
             ? "Grid mode: Ctrl+Click 4 corners to place a curved-surface mark (Shift+G)"
             : "Quad mode: Ctrl+Click 4 corners for a straight mark (Shift+G to switch to curved/grid mode)"}
         />
+
+        {markCreationMode === "grid" && (
+          <>
+            <FooterNumberSetting
+              title="Rows"
+              value={markGridRows}
+              min={2}
+              max={12}
+              setValue={rows => useCanvasStore.getState().setMarkGridRows(CanvasType.MARK, rows)}
+              className="w-10"
+            />
+            <FooterNumberSetting
+              title="Cols"
+              value={markGridCols}
+              min={2}
+              max={12}
+              setValue={cols => useCanvasStore.getState().setMarkGridCols(CanvasType.MARK, cols)}
+              className="w-10"
+            />
+          </>
+        )}
       </Toolbar>
     </div>
   );

--- a/src/components/canvas/mark/MarkCanvas.tsx
+++ b/src/components/canvas/mark/MarkCanvas.tsx
@@ -20,7 +20,7 @@ import { useCanvasStore } from "@/stores/canvas-store";
 import { useMarkStore } from "@/stores/mark-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { CanvasType } from "@/types/types";
-import { snap } from "@/utils/utils";
+import { getShortcutModifierLabel, snap } from "@/utils/utils";
 import Canvas from "../Canvas";
 import MarkImage from "./MarkImage";
 
@@ -367,8 +367,8 @@ function MarkCanvas({ className = "" }: { className?: string }) {
           active={markCreationMode === "grid"}
           onClick={() => useCanvasStore.getState().toggleMarkCreationMode(CanvasType.MARK)}
           tooltip={markCreationMode === "grid"
-            ? "Grid mode: Ctrl+Click 4 corners to place a curved-surface mark (Shift+G)"
-            : "Quad mode: Ctrl+Click 4 corners for a straight mark (Shift+G to switch to curved/grid mode)"}
+            ? `Grid mode: ${getShortcutModifierLabel()}+Click 4 corners to place a curved-surface mark (Shift+G)`
+            : `Quad mode: ${getShortcutModifierLabel()}+Click 4 corners for a straight mark (Shift+G to switch to curved/grid mode)`}
         />
 
         {markCreationMode === "grid" && (

--- a/src/components/canvas/mark/MarkCanvas.tsx
+++ b/src/components/canvas/mark/MarkCanvas.tsx
@@ -4,7 +4,7 @@ import { convertFileSrc, invoke } from "@tauri-apps/api/core";
 import { basename } from "@tauri-apps/api/path";
 import { open } from "@tauri-apps/plugin-dialog";
 import { exists } from "@tauri-apps/plugin-fs";
-import { info, warn } from "@tauri-apps/plugin-log";
+import { error, info, warn } from "@tauri-apps/plugin-log";
 import Konva from "konva";
 import { Grid3x3, TrashIcon } from "lucide-react";
 import { useEffect, useRef } from "react";
@@ -26,7 +26,6 @@ import MarkImage from "./MarkImage";
 
 function MarkCanvas({ className = "" }: { className?: string }) {
   const markImages = useMarkStore(state => state.images);
-  const atlasImages = useAtlasStore(state => state.images);
   const selectedNodes = useCanvasStore(s => s.transientCanvas[CanvasType.MARK].selectedNodes);
   const hoverShape = useCanvasStore(s => s.transientCanvas[CanvasType.MARK].hoverShape);
   const markCreationMode = useCanvasStore(s => s.transientCanvas[CanvasType.MARK].markCreationMode);
@@ -173,9 +172,9 @@ function MarkCanvas({ className = "" }: { className?: string }) {
         }
 
         const applyResults = async (ids: string[], results: string[]) => {
-          results.forEach(async (base64, idx) => {
+          for (const [idx, base64] of results.entries()) {
             const markId = ids[idx];
-            const existingAtlasImage = Object.values(atlasImages).find(image => image.markId === markId);
+            const existingAtlasImage = Object.values(useAtlasStore.getState().images).find(image => image.markId === markId);
 
             const img = new Image();
             img.src = base64;
@@ -200,38 +199,45 @@ function MarkCanvas({ className = "" }: { className?: string }) {
               useAtlasStore.getState().addImage(atlasImage);
             }
             useMarkStore.getState().updateMarkDirty(markId, false);
-          });
+          }
         };
 
         const quadIds = dirtyIds.filter(id => marks[id].markType !== "grid");
         const gridIds = dirtyIds.filter(id => marks[id].markType === "grid");
 
-        if (quadIds.length > 0) {
-          const markPoints = quadIds.flatMap(id =>
-            marks[id].points.flatMap(p => [Math.round(p.x), Math.round(p.y)]),
-          );
+        try {
+          if (quadIds.length > 0) {
+            const markPoints = quadIds.flatMap(id =>
+              marks[id].points.flatMap(p => [Math.round(p.x), Math.round(p.y)]),
+            );
 
-          const results: string[] = await invoke("transform_image", {
-            imgPath: image.filepath,
-            points: markPoints,
-          });
+            const results: string[] = await invoke("transform_image", {
+              imgPath: image.filepath,
+              points: markPoints,
+            });
 
-          await applyResults(quadIds, results);
+            await applyResults(quadIds, results);
+          }
+
+          if (gridIds.length > 0) {
+            const gridMarks = gridIds.map(id => ({
+              rows: marks[id].gridDims!.rows,
+              cols: marks[id].gridDims!.cols,
+              points: marks[id].points.flatMap(p => [Math.round(p.x), Math.round(p.y)]),
+            }));
+
+            const results: string[] = await invoke("transform_image_mesh", {
+              imgPath: image.filepath,
+              marks: gridMarks,
+            });
+
+            await applyResults(gridIds, results);
+          }
         }
-
-        if (gridIds.length > 0) {
-          const gridMarks = gridIds.map(id => ({
-            rows: marks[id].gridDims!.rows,
-            cols: marks[id].gridDims!.cols,
-            points: marks[id].points.flatMap(p => [Math.round(p.x), Math.round(p.y)]),
-          }));
-
-          const results: string[] = await invoke("transform_image_mesh", {
-            imgPath: image.filepath,
-            marks: gridMarks,
-          });
-
-          await applyResults(gridIds, results);
+        catch (e) {
+          toast.error(`Failed to convert marks for ${imgName}: ${e}`);
+          error(`Failed to convert marks for ${imgName}: ${e}`);
+          return;
         }
 
         toast.success(`Finished processing ${dirtyIds.length} marks for ${imgName}`);
@@ -372,6 +378,7 @@ function MarkCanvas({ className = "" }: { className?: string }) {
               value={markGridRows}
               min={2}
               max={12}
+              postProcess={Math.round}
               setValue={rows => useCanvasStore.getState().setMarkGridRows(CanvasType.MARK, rows)}
               className="w-10"
             />
@@ -380,6 +387,7 @@ function MarkCanvas({ className = "" }: { className?: string }) {
               value={markGridCols}
               min={2}
               max={12}
+              postProcess={Math.round}
               setValue={cols => useCanvasStore.getState().setMarkGridCols(CanvasType.MARK, cols)}
               className="w-10"
             />

--- a/src/components/canvas/mark/MarkImage.tsx
+++ b/src/components/canvas/mark/MarkImage.tsx
@@ -1,6 +1,6 @@
 import type Konva from "konva";
 import type { KonvaEventObject } from "konva/lib/Node";
-import type { GridDims, MarkImageType } from "@/stores/mark-store";
+import type { MarkImageType } from "@/stores/mark-store";
 import type { Vec2 } from "@/types/types";
 import { useMemo, useState } from "react";
 import { Group, Image, Line } from "react-konva";
@@ -13,14 +13,11 @@ import { bilinearGrid, classifyCorners, getMiddle, isShortcutModifierPressed } f
 import Mark from "./Mark";
 import MarkPoint from "./MarkPoint";
 
-// Grid density for new curved-surface marks. Fixed for now — the user
-// still shapes the curve by dragging individual interior points after
-// creation, so a denser grid isn't required to get a usable result.
-const DEFAULT_GRID_DIMS: GridDims = { rows: 4, cols: 4 };
-
 function MarkImageComponent({ imageData }: { imageData: MarkImageType }) {
   const marks = useMarkStore(useShallow(s => s.marks));
   const markCreationMode = useCanvasStore(s => s.transientCanvas[CanvasType.MARK].markCreationMode);
+  const markGridRows = useCanvasStore(s => s.transientCanvas[CanvasType.MARK].markGridRows);
+  const markGridCols = useCanvasStore(s => s.transientCanvas[CanvasType.MARK].markGridCols);
 
   const [image] = useImage(imageData.src);
   const [currentPoints, setCurrentPoints] = useState<Vec2[]>([]);
@@ -35,7 +32,8 @@ function MarkImageComponent({ imageData }: { imageData: MarkImageType }) {
     if (updated.length === 4) {
       if (markCreationMode === "grid") {
         const corners = classifyCorners(updated);
-        const gridPoints = bilinearGrid(corners, DEFAULT_GRID_DIMS.rows, DEFAULT_GRID_DIMS.cols);
+        const gridDims = { rows: markGridRows, cols: markGridCols };
+        const gridPoints = bilinearGrid(corners, gridDims.rows, gridDims.cols);
 
         useMarkStore.getState().addMark(imageData.id, {
           id: crypto.randomUUID(),
@@ -43,7 +41,7 @@ function MarkImageComponent({ imageData }: { imageData: MarkImageType }) {
           points: gridPoints,
           dirty: true,
           markType: "grid",
-          gridDims: DEFAULT_GRID_DIMS,
+          gridDims,
         });
       }
       else {

--- a/src/components/canvas/mark/MarkImage.tsx
+++ b/src/components/canvas/mark/MarkImage.tsx
@@ -1,19 +1,26 @@
 import type Konva from "konva";
 import type { KonvaEventObject } from "konva/lib/Node";
-import type { MarkImageType } from "@/stores/mark-store";
+import type { GridDims, MarkImageType } from "@/stores/mark-store";
 import type { Vec2 } from "@/types/types";
 import { useMemo, useState } from "react";
 import { Group, Image, Line } from "react-konva";
 import useImage from "use-image";
 import { useShallow } from "zustand/react/shallow";
+import { useCanvasStore } from "@/stores/canvas-store";
 import { useMarkStore } from "@/stores/mark-store";
-import { Colors } from "@/types/types";
-import { getMiddle, isShortcutModifierPressed } from "@/utils/utils";
+import { CanvasType, Colors } from "@/types/types";
+import { bilinearGrid, classifyCorners, getMiddle, isShortcutModifierPressed } from "@/utils/utils";
 import Mark from "./Mark";
 import MarkPoint from "./MarkPoint";
 
+// Grid density for new curved-surface marks. Fixed for now — the user
+// still shapes the curve by dragging individual interior points after
+// creation, so a denser grid isn't required to get a usable result.
+const DEFAULT_GRID_DIMS: GridDims = { rows: 4, cols: 4 };
+
 function MarkImageComponent({ imageData }: { imageData: MarkImageType }) {
   const marks = useMarkStore(useShallow(s => s.marks));
+  const markCreationMode = useCanvasStore(s => s.transientCanvas[CanvasType.MARK].markCreationMode);
 
   const [image] = useImage(imageData.src);
   const [currentPoints, setCurrentPoints] = useState<Vec2[]>([]);
@@ -26,20 +33,36 @@ function MarkImageComponent({ imageData }: { imageData: MarkImageType }) {
 
     const updated = [...currentPoints, { x: pos.x, y: pos.y }];
     if (updated.length === 4) {
-      const center = getMiddle(updated);
-      const sortedPoints = updated.sort((a, b) => {
-        const angleA = Math.atan2(center.y - a.y, center.x - a.x);
-        const angleB = Math.atan2(center.y - b.y, center.x - b.x);
+      if (markCreationMode === "grid") {
+        const corners = classifyCorners(updated);
+        const gridPoints = bilinearGrid(corners, DEFAULT_GRID_DIMS.rows, DEFAULT_GRID_DIMS.cols);
 
-        return angleA < angleB ? 1 : -1;
-      });
+        useMarkStore.getState().addMark(imageData.id, {
+          id: crypto.randomUUID(),
+          imageId: imageData.id,
+          points: gridPoints,
+          dirty: true,
+          markType: "grid",
+          gridDims: DEFAULT_GRID_DIMS,
+        });
+      }
+      else {
+        const center = getMiddle(updated);
+        const sortedPoints = updated.sort((a, b) => {
+          const angleA = Math.atan2(center.y - a.y, center.x - a.x);
+          const angleB = Math.atan2(center.y - b.y, center.x - b.x);
 
-      useMarkStore.getState().addMark(imageData.id, {
-        id: crypto.randomUUID(),
-        imageId: imageData.id,
-        points: sortedPoints,
-        dirty: true,
-      });
+          return angleA < angleB ? 1 : -1;
+        });
+
+        useMarkStore.getState().addMark(imageData.id, {
+          id: crypto.randomUUID(),
+          imageId: imageData.id,
+          points: sortedPoints,
+          dirty: true,
+          markType: "quad",
+        });
+      }
 
       setCurrentPoints([]);
     }

--- a/src/stores/canvas-store.ts
+++ b/src/stores/canvas-store.ts
@@ -32,6 +32,7 @@ type CanvasStore = {
   setSelectedNodes: (canvas: CanvasType, nodes: Node<NodeConfig>[]) => void;
   setHoverShape: (canvas: CanvasType, shape: Konva.Shape | null) => void;
   toggleMarkCreationMode: (canvas: CanvasType) => void;
+  setMarkCreationMode: (canvas: CanvasType, mode: "quad" | "grid") => void;
   setMarkGridRows: (canvas: CanvasType, rows: number) => void;
   setMarkGridCols: (canvas: CanvasType, cols: number) => void;
 };
@@ -68,6 +69,10 @@ export const useCanvasStore = create(
         set((state) => {
           state.transientCanvas[canvas].markCreationMode
             = state.transientCanvas[canvas].markCreationMode === "quad" ? "grid" : "quad";
+        }),
+      setMarkCreationMode: (canvas, mode) =>
+        set((state) => {
+          state.transientCanvas[canvas].markCreationMode = mode;
         }),
       setMarkGridRows: (canvas, rows) =>
         set((state) => {

--- a/src/stores/canvas-store.ts
+++ b/src/stores/canvas-store.ts
@@ -17,6 +17,9 @@ export type TransientCanvasState = {
   selectedNodes: Node<NodeConfig>[];
   /** Mark canvas only: which mark type Ctrl+Click creates next. */
   markCreationMode: "quad" | "grid";
+  /** Mark canvas only: rows/cols used to seed the next new grid mark. */
+  markGridRows: number;
+  markGridCols: number;
 };
 
 type CanvasStore = {
@@ -29,6 +32,8 @@ type CanvasStore = {
   setSelectedNodes: (canvas: CanvasType, nodes: Node<NodeConfig>[]) => void;
   setHoverShape: (canvas: CanvasType, shape: Konva.Shape | null) => void;
   toggleMarkCreationMode: (canvas: CanvasType) => void;
+  setMarkGridRows: (canvas: CanvasType, rows: number) => void;
+  setMarkGridCols: (canvas: CanvasType, cols: number) => void;
 };
 
 export const useCanvasStore = create(
@@ -39,8 +44,8 @@ export const useCanvasStore = create(
         [CanvasType.ATLAS]: { scale: 1, x: 0, y: 0 },
       },
       transientCanvas: {
-        [CanvasType.MARK]: { hoverShape: null, selectedNodes: [], markCreationMode: "quad" },
-        [CanvasType.ATLAS]: { hoverShape: null, selectedNodes: [], markCreationMode: "quad" },
+        [CanvasType.MARK]: { hoverShape: null, selectedNodes: [], markCreationMode: "quad", markGridRows: 4, markGridCols: 4 },
+        [CanvasType.ATLAS]: { hoverShape: null, selectedNodes: [], markCreationMode: "quad", markGridRows: 4, markGridCols: 4 },
       },
       setCanvasScale: (canvas, scale) =>
         set((state) => {
@@ -63,6 +68,14 @@ export const useCanvasStore = create(
         set((state) => {
           state.transientCanvas[canvas].markCreationMode
             = state.transientCanvas[canvas].markCreationMode === "quad" ? "grid" : "quad";
+        }),
+      setMarkGridRows: (canvas, rows) =>
+        set((state) => {
+          state.transientCanvas[canvas].markGridRows = rows;
+        }),
+      setMarkGridCols: (canvas, cols) =>
+        set((state) => {
+          state.transientCanvas[canvas].markGridCols = cols;
         }),
     })),
     {

--- a/src/stores/canvas-store.ts
+++ b/src/stores/canvas-store.ts
@@ -15,6 +15,8 @@ export type CanvasState = {
 export type TransientCanvasState = {
   hoverShape: Konva.Shape | null;
   selectedNodes: Node<NodeConfig>[];
+  /** Mark canvas only: which mark type Ctrl+Click creates next. */
+  markCreationMode: "quad" | "grid";
 };
 
 type CanvasStore = {
@@ -26,6 +28,7 @@ type CanvasStore = {
 
   setSelectedNodes: (canvas: CanvasType, nodes: Node<NodeConfig>[]) => void;
   setHoverShape: (canvas: CanvasType, shape: Konva.Shape | null) => void;
+  toggleMarkCreationMode: (canvas: CanvasType) => void;
 };
 
 export const useCanvasStore = create(
@@ -36,8 +39,8 @@ export const useCanvasStore = create(
         [CanvasType.ATLAS]: { scale: 1, x: 0, y: 0 },
       },
       transientCanvas: {
-        [CanvasType.MARK]: { hoverShape: null, selectedNodes: [] },
-        [CanvasType.ATLAS]: { hoverShape: null, selectedNodes: [] },
+        [CanvasType.MARK]: { hoverShape: null, selectedNodes: [], markCreationMode: "quad" },
+        [CanvasType.ATLAS]: { hoverShape: null, selectedNodes: [], markCreationMode: "quad" },
       },
       setCanvasScale: (canvas, scale) =>
         set((state) => {
@@ -55,6 +58,11 @@ export const useCanvasStore = create(
       setHoverShape: (canvas, shape) =>
         set((state) => {
           state.transientCanvas[canvas].hoverShape = shape;
+        }),
+      toggleMarkCreationMode: canvas =>
+        set((state) => {
+          state.transientCanvas[canvas].markCreationMode
+            = state.transientCanvas[canvas].markCreationMode === "quad" ? "grid" : "quad";
         }),
     })),
     {

--- a/src/stores/mark-store.ts
+++ b/src/stores/mark-store.ts
@@ -3,11 +3,20 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 
+export type GridDims = {
+  rows: number;
+  cols: number;
+};
+
 export type MarkType = {
   id: string;
   imageId: string;
   points: Vec2[];
   dirty: boolean;
+  /** Defaults to "quad" for marks persisted before grid marks existed. */
+  markType?: "quad" | "grid";
+  /** Only set when markType is "grid" — points is a row-major rows*cols grid. */
+  gridDims?: GridDims;
 };
 
 export type MarkImageType = {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -53,3 +53,41 @@ export function snapPowerOfTwo(x: number) {
 export function clamp(x: number, min: number, max: number) {
   return Math.max(Math.min(x, max), min);
 }
+
+/**
+ * Classifies 4 arbitrarily-ordered corner points into { tl, tr, bl, br } by
+ * comparing each to the centroid. Works for any reasonably convex quad the
+ * user clicks (not just axis-aligned ones) — the common case for a mark.
+ */
+export function classifyCorners(points: Vec2[]): { tl: Vec2; tr: Vec2; bl: Vec2; br: Vec2 } {
+  const center = getMiddle(points);
+  const tl = points.find(p => p.x < center.x && p.y < center.y) ?? points[0];
+  const tr = points.find(p => p.x >= center.x && p.y < center.y) ?? points[1];
+  const bl = points.find(p => p.x < center.x && p.y >= center.y) ?? points[2];
+  const br = points.find(p => p.x >= center.x && p.y >= center.y) ?? points[3];
+  return { tl, tr, bl, br };
+}
+
+/**
+ * Bilinearly interpolates a rows x cols grid of points across a quad defined
+ * by its 4 corners, returned row-major (row 0 first, left-to-right).
+ * Used to seed a new curved-surface (grid) mark's interior control points —
+ * the user then drags individual points to trace the actual curve.
+ */
+export function bilinearGrid(corners: { tl: Vec2; tr: Vec2; bl: Vec2; br: Vec2 }, rows: number, cols: number): Vec2[] {
+  const { tl, tr, bl, br } = corners;
+  const points: Vec2[] = [];
+
+  for (let i = 0; i < rows; i++) {
+    const v = rows === 1 ? 0 : i / (rows - 1);
+    const left = lerpVec2(tl, bl, v);
+    const right = lerpVec2(tr, br, v);
+
+    for (let j = 0; j < cols; j++) {
+      const u = cols === 1 ? 0 : j / (cols - 1);
+      points.push(lerpVec2(left, right, u));
+    }
+  }
+
+  return points;
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -55,16 +55,33 @@ export function clamp(x: number, min: number, max: number) {
 }
 
 /**
- * Classifies 4 arbitrarily-ordered corner points into { tl, tr, bl, br } by
- * comparing each to the centroid. Works for any reasonably convex quad the
- * user clicks (not just axis-aligned ones) — the common case for a mark.
+ * Classifies 4 arbitrarily-ordered corner points into { tl, tr, bl, br }.
+ * Sorts by angle around the centroid first (rotation-invariant — this is
+ * what makes it safe for any quad orientation the user clicks, not just
+ * axis-aligned ones), then starts the cycle at whichever point is closest to
+ * top-left. Quadrant membership tests alone aren't enough here: a rotated
+ * quad (e.g. a diamond) can put two points in one quadrant and none in
+ * another, which silently duplicates a corner and drops one entirely.
  */
 export function classifyCorners(points: Vec2[]): { tl: Vec2; tr: Vec2; bl: Vec2; br: Vec2 } {
   const center = getMiddle(points);
-  const tl = points.find(p => p.x < center.x && p.y < center.y) ?? points[0];
-  const tr = points.find(p => p.x >= center.x && p.y < center.y) ?? points[1];
-  const bl = points.find(p => p.x < center.x && p.y >= center.y) ?? points[2];
-  const br = points.find(p => p.x >= center.x && p.y >= center.y) ?? points[3];
+  const sorted = [...points].sort((a, b) => {
+    const angleA = Math.atan2(a.y - center.y, a.x - center.x);
+    const angleB = Math.atan2(b.y - center.y, b.x - center.x);
+    return angleA - angleB;
+  });
+
+  let startIdx = 0;
+  let best = Infinity;
+  sorted.forEach((p, i) => {
+    const score = p.x + p.y;
+    if (score < best) {
+      best = score;
+      startIdx = i;
+    }
+  });
+
+  const [tl, tr, br, bl] = [0, 1, 2, 3].map(offset => sorted[(startIdx + offset) % 4]);
   return { tl, tr, bl, br };
 }
 


### PR DESCRIPTION
## Summary
- New Rust backend command `transform_image_mesh`: piecewise-affine mesh warp via barycentric backward-mapping, alongside the existing 4-point `transform_image` (unchanged)
- New "grid" mark type in the frontend: an NxM grid of control points seeded from 4 clicked corners, with rows/cols configurable via a toolbar stepper
- Drag any interior grid point (not just corners) to trace an actual curve in the photo before converting
- New toolbar toggle (with a dedicated grid-mode icon, dimmed when inactive) to switch between quad and grid mark creation, plus a `Shift+G` shortcut

## Why
The existing extraction is a single 4-point planar homography, which can only flatten a flat plane. It has no way to handle a texture wrapped around something curved — a label on a bottle, a sign on a pipe. This adds a general-purpose curved-surface path without touching the existing quad workflow at all.

## This is v1
This ships straight-line grid segments between control points — you trace the curve by placing more points, not by adjusting per-point curvature. A follow-up (bezier/tension per vertex, so only the parts of a mark that actually curve need curve treatment while corners stay sharp) is planned on top of this same mesh-warp foundation, once this lands.

## Test plan
- [x] `cargo test` passes (4 unit tests covering the mesh warp math, including edge/corner sampling)
- [x] `tsc --noEmit` / `eslint` clean
- [x] Hands-on tested end to end on a real bottle-label photo: placed a grid mark, dragged interior points to trace the label's curvature, converted, and the output is a correctly flattened rectangle