### PR TITLE
Add undo/redo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "tw-animate-css": "^1.4.0",
         "use-image": "^1.1.4",
         "uuid": "^13.0.0",
+        "zundo": "^2.3.0",
         "zustand": "^5.0.11"
       },
       "devDependencies": {
@@ -13312,6 +13313,24 @@
       "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
       "peerDependencies": {
         "zod": "^3.25 || ^4"
+      }
+    },
+    "node_modules/zundo": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/zundo/-/zundo-2.3.0.tgz",
+      "integrity": "sha512-4GXYxXA17SIKYhVbWHdSEU04P697IMyVGXrC2TnzoyohEAWytFNOKqOp5gTGvaW93F/PM5Y0evbGtOPF0PWQwQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/charkour"
+      },
+      "peerDependencies": {
+        "zustand": "^4.3.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zustand": {
+          "optional": false
+        }
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "tw-animate-css": "^1.4.0",
     "use-image": "^1.1.4",
     "uuid": "^13.0.0",
+    "zundo": "^2.3.0",
     "zustand": "^5.0.11"
   },
   "devDependencies": {

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -30,9 +30,14 @@ export function ToolbarAction({ Icon, onClick, disabled = false, tooltip, size =
   );
 }
 
-export function Toolbar({ children }: { children: ReactNode }) {
+const POSITION_CLASSES = {
+  "top-left": "top-0 left-0 rounded-b-xl",
+  "top-right": "top-0 right-0 rounded-b-xl",
+} as const;
+
+export function Toolbar({ children, position = "top-left" }: { children: ReactNode; position?: keyof typeof POSITION_CLASSES }) {
   return (
-    <div className="flex text-center items-center absolute top-0 left-0 bg-dark-main-darker p-2 rounded-b-xl gap-2">
+    <div className={`flex text-center items-center absolute bg-dark-main-darker p-2 gap-2 ${POSITION_CLASSES[position]}`}>
       {children}
     </div>
   );

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -37,7 +37,7 @@ const POSITION_CLASSES = {
 
 export function Toolbar({ children, position = "top-left" }: { children: ReactNode; position?: keyof typeof POSITION_CLASSES }) {
   return (
-    <div className={`flex text-center items-center absolute bg-dark-main-darker p-2 gap-2 ${POSITION_CLASSES[position]}`}>
+    <div data-no-panel-resize className={`flex text-center items-center absolute bg-dark-main-darker p-2 gap-2 ${POSITION_CLASSES[position]}`}>
       {children}
     </div>
   );

--- a/src/components/canvas/Canvas.tsx
+++ b/src/components/canvas/Canvas.tsx
@@ -74,9 +74,7 @@ function Canvas({ canvasType, onDelete, transformerRef, contextMenu, children, c
     <div className="h-full" tabIndex={-1} onKeyDown={handleShortcuts}>
       <PopupConfirm
         title="Delete Selected"
-        description={
-          "Are you sure you want to delete the selected images?\nThis cannot be undone"
-        }
+        description="Are you sure you want to delete the selected images?"
         confirmLabel="Delete"
         open={openConfirmation}
         setOpen={setOpenConfirmation}

--- a/src/components/canvas/CanvasSplitter.tsx
+++ b/src/components/canvas/CanvasSplitter.tsx
@@ -19,7 +19,11 @@ function CanvasSplitter({ className }: { className?: string }) {
           panelRef={leftPanelRef}
           className="bg-dark-main"
           minSize={PANEL_MIN_SIZE}
-          onDoubleClick={() => leftPanelRef.current?.resize("80%")}
+          onDoubleClick={(e) => {
+            if ((e.target as HTMLElement).closest("[data-no-panel-resize]"))
+              return;
+            leftPanelRef.current?.resize("80%");
+          }}
         >
           <MarkCanvas />
         </Panel>
@@ -38,7 +42,11 @@ function CanvasSplitter({ className }: { className?: string }) {
           id="atlasPanel"
           className="bg-dark-main drop-shadow-2xl"
           minSize={PANEL_MIN_SIZE}
-          onDoubleClick={() => leftPanelRef.current?.resize("20%")}
+          onDoubleClick={(e) => {
+            if ((e.target as HTMLElement).closest("[data-no-panel-resize]"))
+              return;
+            leftPanelRef.current?.resize("20%");
+          }}
         >
           <AtlasCanvas />
         </Panel>

--- a/src/components/canvas/atlas/AtlasCanvas.tsx
+++ b/src/components/canvas/atlas/AtlasCanvas.tsx
@@ -4,11 +4,13 @@ import { save } from "@tauri-apps/plugin-dialog";
 import { writeFile } from "@tauri-apps/plugin-fs";
 import { info } from "@tauri-apps/plugin-log";
 import { openPath, revealItemInDir } from "@tauri-apps/plugin-opener";
+import { Redo2, Undo2 } from "lucide-react";
 import { useRef } from "react";
 import { BiSolidImageAlt } from "react-icons/bi";
 import { PiSelection } from "react-icons/pi";
 import { Group, Rect, Text } from "react-konva";
 import { toast } from "sonner";
+import { useStore } from "zustand";
 import { Toolbar, ToolbarAction } from "@/components/Toolbar";
 import { ContextMenuCheckboxItem, ContextMenuGroup, ContextMenuItem, ContextMenuSeparator, ContextMenuShortcut } from "@/components/ui/ContextMenu";
 import { useAtlasStore } from "@/stores/atlas-store";
@@ -26,6 +28,8 @@ function AtlasCanvas({ className }: { className?: string }) {
   const masterGroupRef = useRef<Konva.Group>(null);
   const transformerRef = useRef<Konva.Transformer>(null);
   const shortcutModifier = getShortcutModifierLabel();
+  const canUndo = useStore(useAtlasStore.temporal, s => s.pastStates.length > 0);
+  const canRedo = useStore(useAtlasStore.temporal, s => s.futureStates.length > 0);
 
   const exportCanvas = async () => {
     const exportPath = await save({
@@ -168,6 +172,16 @@ function AtlasCanvas({ className }: { className?: string }) {
         if (isShortcutModifierPressed(e))
           exportSelected();
         break;
+      case "KeyZ":
+        if (isShortcutModifierPressed(e)) {
+          // Stop the webview's own text-undo from also firing.
+          e.preventDefault();
+          if (e.shiftKey)
+            useAtlasStore.temporal.getState().redo();
+          else
+            useAtlasStore.temporal.getState().undo();
+        }
+        break;
       default:
         break;
     }
@@ -234,6 +248,11 @@ function AtlasCanvas({ className }: { className?: string }) {
       <Toolbar>
         <ToolbarAction Icon={BiSolidImageAlt} onClick={exportCanvas} tooltip={`Export Atlas (${shortcutModifier}+E)`} />
         <ToolbarAction Icon={PiSelection} onClick={exportSelected} tooltip={`Export Selected (${shortcutModifier}+S)`} />
+      </Toolbar>
+
+      <Toolbar position="top-right">
+        <ToolbarAction Icon={Undo2} disabled={!canUndo} onClick={() => useAtlasStore.temporal.getState().undo()} tooltip={`Undo (${shortcutModifier}+Z)`} />
+        <ToolbarAction Icon={Redo2} disabled={!canRedo} onClick={() => useAtlasStore.temporal.getState().redo()} tooltip={`Redo (Shift+${shortcutModifier}+Z)`} />
       </Toolbar>
     </div>
   );

--- a/src/components/canvas/mark/Mark.tsx
+++ b/src/components/canvas/mark/Mark.tsx
@@ -1,5 +1,5 @@
 import type { MarkType } from "@/stores/mark-store";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Group, Line } from "react-konva";
 import { useMarkStore } from "@/stores/mark-store";
 import { Colors } from "@/types/types";
@@ -9,6 +9,18 @@ import MarkPoint from "./MarkPoint";
 function Mark({ mark, scale = 1 }: { mark: MarkType; scale?: number }) {
   const [markOffset, setMarkOffset] = useState({ x: 0, y: 0 });
   const [points, setPoints] = useState(mark.points);
+
+  // points is a local copy (needed for live drag feedback via onDragMove,
+  // before a drag commits to the store on drag-end). It only ever gets
+  // seeded from mark.points once at mount, so an external change to the
+  // store's points -- undo/redo being the main case -- was never reflected:
+  // the store reverted correctly, but this component kept rendering the
+  // stale local copy. Re-sync whenever the prop actually changes.
+  useEffect(() => {
+    // eslint-disable-next-line react/set-state-in-effect
+    setPoints(mark.points);
+  }, [mark.points]);
+
   const pointsFlat = useMemo(() => points.flatMap(p => [p.x, p.y]), [points]);
 
   const gridPoints = useMemo(() => {

--- a/src/components/canvas/mark/MarkCanvas.tsx
+++ b/src/components/canvas/mark/MarkCanvas.tsx
@@ -19,7 +19,7 @@ import { useCanvasStore } from "@/stores/canvas-store";
 import { useMarkStore } from "@/stores/mark-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { CanvasType } from "@/types/types";
-import { snap } from "@/utils/utils";
+import { isShortcutModifierPressed, snap } from "@/utils/utils";
 import Canvas from "../Canvas";
 import MarkImage from "./MarkImage";
 
@@ -296,6 +296,16 @@ function MarkCanvas({ className = "" }: { className?: string }) {
       case "KeyR":
         if (e.shiftKey)
           convertMarks();
+        break;
+      case "KeyZ":
+        if (isShortcutModifierPressed(e)) {
+          // Stop the webview's own text-undo from also firing.
+          e.preventDefault();
+          if (e.shiftKey)
+            useMarkStore.temporal.getState().redo();
+          else
+            useMarkStore.temporal.getState().undo();
+        }
         break;
       default:
         break;

--- a/src/components/canvas/mark/MarkCanvas.tsx
+++ b/src/components/canvas/mark/MarkCanvas.tsx
@@ -6,12 +6,13 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { exists } from "@tauri-apps/plugin-fs";
 import { info, warn } from "@tauri-apps/plugin-log";
 import Konva from "konva";
-import { TrashIcon } from "lucide-react";
+import { Redo2, TrashIcon, Undo2 } from "lucide-react";
 import { useEffect, useRef } from "react";
 import { CgAdd } from "react-icons/cg";
 import { FaPlay } from "react-icons/fa";
 import { Line } from "react-konva";
 import { toast } from "sonner";
+import { useStore } from "zustand";
 import { Toolbar, ToolbarAction } from "@/components/Toolbar";
 import { ContextMenuGroup, ContextMenuItem, ContextMenuSeparator, ContextMenuShortcut, ContextMenuSub, ContextMenuSubContent, ContextMenuSubTrigger } from "@/components/ui/ContextMenu";
 import { useAtlasStore } from "@/stores/atlas-store";
@@ -19,7 +20,7 @@ import { useCanvasStore } from "@/stores/canvas-store";
 import { useMarkStore } from "@/stores/mark-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { CanvasType } from "@/types/types";
-import { isShortcutModifierPressed, snap } from "@/utils/utils";
+import { getShortcutModifierLabel, isShortcutModifierPressed, snap } from "@/utils/utils";
 import Canvas from "../Canvas";
 import MarkImage from "./MarkImage";
 
@@ -29,6 +30,8 @@ function MarkCanvas({ className = "" }: { className?: string }) {
   const selectedNodes = useCanvasStore(s => s.transientCanvas[CanvasType.MARK].selectedNodes);
   const hoverShape = useCanvasStore(s => s.transientCanvas[CanvasType.MARK].hoverShape);
   const snapSize = useSettingsStore(s => s.snap);
+  const canUndo = useStore(useMarkStore.temporal, s => s.pastStates.length > 0);
+  const canRedo = useStore(useMarkStore.temporal, s => s.futureStates.length > 0);
 
   const transformerRef = useRef<Konva.Transformer>(null);
 
@@ -333,6 +336,11 @@ function MarkCanvas({ className = "" }: { className?: string }) {
       <Toolbar>
         <ToolbarAction Icon={CgAdd} onClick={loadImages} tooltip="Load Images (Shift+A)" />
         <ToolbarAction Icon={FaPlay} size={4} onClick={() => convertMarks()} tooltip="Convert Marks (Shift+R)" />
+      </Toolbar>
+
+      <Toolbar position="top-right">
+        <ToolbarAction Icon={Undo2} disabled={!canUndo} onClick={() => useMarkStore.temporal.getState().undo()} tooltip={`Undo (${getShortcutModifierLabel()}+Z)`} />
+        <ToolbarAction Icon={Redo2} disabled={!canRedo} onClick={() => useMarkStore.temporal.getState().redo()} tooltip={`Redo (Shift+${getShortcutModifierLabel()}+Z)`} />
       </Toolbar>
     </div>
   );

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -50,6 +50,8 @@ export default function Footer() {
             <ShortcutHelper shortcut={`${shortcutModifier}+Click`} description="Add Mark Point" />
             <ShortcutHelper shortcut="Shift+R" description="Convert Marks" />
             <ShortcutHelper shortcut="Alt+Click" description="Delete Mark" />
+            <ShortcutHelper shortcut={`${shortcutModifier}+Z`} description="Undo" />
+            <ShortcutHelper shortcut={`Shift+${shortcutModifier}+Z`} description="Redo" />
 
             <hr />
 

--- a/src/stores/atlas-store.ts
+++ b/src/stores/atlas-store.ts
@@ -1,5 +1,6 @@
 import type { ImageType, Vec2 } from "@/types/types";
 import { del, get, set } from "idb-keyval";
+import { temporal } from "zundo";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
@@ -34,51 +35,80 @@ const indexedDBStorage = {
 
 export const useAtlasStore = create(
   persist(
-    immer<AtlasStore>(set => ({
-      images: {},
+    temporal(
+      immer<AtlasStore>(set => ({
+        images: {},
 
-      addImage: image =>
-        set((state) => {
-          state.images[image.id] = image;
-        }),
+        addImage: image =>
+          set((state) => {
+            state.images[image.id] = image;
+          }),
 
-      updateImagePosition: (imageId, newPos) =>
-        set((state) => {
-          if (!state.images[imageId])
-            return;
-          state.images[imageId].position = newPos;
-        }),
+        updateImagePosition: (imageId, newPos) =>
+          set((state) => {
+            if (!state.images[imageId])
+              return;
+            state.images[imageId].position = newPos;
+          }),
 
-      updateImageScale: (imageId, newScale) =>
-        set((state) => {
-          if (!state.images[imageId])
-            return;
-          state.images[imageId].scale = newScale;
-        }),
+        updateImageScale: (imageId, newScale) =>
+          set((state) => {
+            if (!state.images[imageId])
+              return;
+            state.images[imageId].scale = newScale;
+          }),
 
-      updateImageRotation: (imageId, newRot) =>
-        set((state) => {
-          if (!state.images[imageId])
-            return;
-          state.images[imageId].rotation = newRot;
-        }),
+        updateImageRotation: (imageId, newRot) =>
+          set((state) => {
+            if (!state.images[imageId])
+              return;
+            state.images[imageId].rotation = newRot;
+          }),
 
-      updateImageBase64: (imageId, base64) =>
-        set((state) => {
-          if (!state.images[imageId])
-            return;
-          state.images[imageId].base64 = base64;
-        }),
+        updateImageBase64: (imageId, base64) =>
+          set((state) => {
+            if (!state.images[imageId])
+              return;
+            state.images[imageId].base64 = base64;
+          }),
 
-      removeImage: imageId =>
-        set((state) => {
-          const image = state.images[imageId];
-          if (!image)
-            return;
+        removeImage: imageId =>
+          set((state) => {
+            const image = state.images[imageId];
+            if (!image)
+              return;
 
-          delete state.images[imageId];
-        }),
-    })),
+            delete state.images[imageId];
+          }),
+      })),
+      {
+        limit: 30,
+        // Same leading-edge requirement as mark-store's undo (see its own
+        // comment for the full reasoning): a transform gesture fires 3
+        // separate set() calls (scale, rotation, position) that must
+        // coalesce into one undo step, and zundo's handleSet receives the
+        // state from BEFORE the triggering set, so only a leading-edge
+        // debounce restores to the pre-gesture state rather than a no-op.
+        handleSet: handleSet => leadingDebounce<typeof handleSet>(handleSet, 300),
+      },
+    ),
     { name: "atlas-storage", storage: createJSONStorage(() => indexedDBStorage) },
   ),
 );
+
+/** See mark-store.ts's identical helper for the full rationale. */
+function leadingDebounce<T extends (...args: Parameters<T>) => void>(fn: T, delayMs: number): T {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return ((...args: Parameters<T>) => {
+    const isBurstStart = timer === undefined;
+
+    if (timer)
+      clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = undefined;
+    }, delayMs);
+
+    if (isBurstStart)
+      fn(...args);
+  }) as T;
+}

--- a/src/stores/atlas-store.ts
+++ b/src/stores/atlas-store.ts
@@ -82,7 +82,7 @@ export const useAtlasStore = create(
           }),
       })),
       {
-        limit: 30,
+        limit: 50,
         // Same leading-edge requirement as mark-store's undo (see its own
         // comment for the full reasoning): a transform gesture fires 3
         // separate set() calls (scale, rotation, position) that must

--- a/src/stores/atlas-store.ts
+++ b/src/stores/atlas-store.ts
@@ -4,6 +4,7 @@ import { temporal } from "zundo";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
+import { leadingDebounce } from "./store-utils";
 
 export type AtlasImageType = {
   markId: string;
@@ -95,20 +96,3 @@ export const useAtlasStore = create(
     { name: "atlas-storage", storage: createJSONStorage(() => indexedDBStorage) },
   ),
 );
-
-/** See mark-store.ts's identical helper for the full rationale. */
-function leadingDebounce<T extends (...args: Parameters<T>) => void>(fn: T, delayMs: number): T {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  return ((...args: Parameters<T>) => {
-    const isBurstStart = timer === undefined;
-
-    if (timer)
-      clearTimeout(timer);
-    timer = setTimeout(() => {
-      timer = undefined;
-    }, delayMs);
-
-    if (isBurstStart)
-      fn(...args);
-  }) as T;
-}

--- a/src/stores/mark-store.ts
+++ b/src/stores/mark-store.ts
@@ -1,4 +1,5 @@
 import type { ImageType, Vec2 } from "@/types/types";
+import { temporal } from "zundo";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
@@ -35,92 +36,114 @@ type MarkStore = {
 
 export const useMarkStore = create(
   persist(
-    immer<MarkStore>(set => ({
-      images: {},
-      marks: {},
+    temporal(
+      immer<MarkStore>(set => ({
+        images: {},
+        marks: {},
 
-      addImage: image =>
-        set((state) => {
-          state.images[image.id] = image;
-        }),
+        addImage: image =>
+          set((state) => {
+            state.images[image.id] = image;
+          }),
 
-      updateImagePosition: (imageId, newPos) =>
-        set((state) => {
-          if (!state.images[imageId])
-            return;
-          state.images[imageId].position = newPos;
-        }),
+        updateImagePosition: (imageId, newPos) =>
+          set((state) => {
+            if (!state.images[imageId])
+              return;
+            state.images[imageId].position = newPos;
+          }),
 
-      updateImageScale: (imageId, newScale) =>
-        set((state) => {
-          if (!state.images[imageId])
-            return;
-          state.images[imageId].scale = newScale;
-        }),
+        updateImageScale: (imageId, newScale) =>
+          set((state) => {
+            if (!state.images[imageId])
+              return;
+            state.images[imageId].scale = newScale;
+          }),
 
-      updateImageRotation: (imageId, newRot) =>
-        set((state) => {
-          if (!state.images[imageId])
-            return;
-          state.images[imageId].rotation = newRot;
-        }),
+        updateImageRotation: (imageId, newRot) =>
+          set((state) => {
+            if (!state.images[imageId])
+              return;
+            state.images[imageId].rotation = newRot;
+          }),
 
-      addMark: (imageId, mark) =>
-        set((state) => {
-          if (!state.images[imageId])
-            return;
-          state.marks[mark.id] = mark;
-          state.images[imageId].markIds.push(mark.id);
-        }),
+        addMark: (imageId, mark) =>
+          set((state) => {
+            if (!state.images[imageId])
+              return;
+            state.marks[mark.id] = mark;
+            state.images[imageId].markIds.push(mark.id);
+          }),
 
-      updateMark: (markId, newPoints) =>
-        set((state) => {
-          if (!state.marks[markId])
-            return;
-          state.marks[markId].points = newPoints;
-        }),
+        updateMark: (markId, newPoints) =>
+          set((state) => {
+            if (!state.marks[markId])
+              return;
+            state.marks[markId].points = newPoints;
+          }),
 
-      updateMarkPoint: (markId, pointIdx, newPoint) =>
-        set((state) => {
-          if (!state.marks[markId])
-            return;
-          state.marks[markId].points[pointIdx] = newPoint;
-        }),
+        updateMarkPoint: (markId, pointIdx, newPoint) =>
+          set((state) => {
+            if (!state.marks[markId])
+              return;
+            state.marks[markId].points[pointIdx] = newPoint;
+          }),
 
-      updateMarkDirty: (markId, dirty) =>
-        set((state) => {
-          if (!state.marks[markId])
-            return;
-          state.marks[markId].dirty = dirty;
-        }),
+        updateMarkDirty: (markId, dirty) =>
+          set((state) => {
+            if (!state.marks[markId])
+              return;
+            state.marks[markId].dirty = dirty;
+          }),
 
-      removeMark: markId =>
-        set((state) => {
-          const mark = state.marks[markId];
-          if (!mark)
-            return;
-          if (!state.images[mark.imageId])
-            return;
+        removeMark: markId =>
+          set((state) => {
+            const mark = state.marks[markId];
+            if (!mark)
+              return;
+            if (!state.images[mark.imageId])
+              return;
 
-          delete state.marks[markId];
-          state.images[mark.imageId].markIds = state.images[mark.imageId].markIds.filter(
-            id => id !== markId,
-          );
-        }),
-
-      removeImage: imageId =>
-        set((state) => {
-          const image = state.images[imageId];
-          if (!image)
-            return;
-
-          for (const markId of image.markIds) {
             delete state.marks[markId];
-          }
+            state.images[mark.imageId].markIds = state.images[mark.imageId].markIds.filter(
+              id => id !== markId,
+            );
+          }),
 
-          delete state.images[imageId];
-        }),
-    })),
+        removeImage: imageId =>
+          set((state) => {
+            const image = state.images[imageId];
+            if (!image)
+              return;
+
+            for (const markId of image.markIds) {
+              delete state.marks[markId];
+            }
+
+            delete state.images[imageId];
+          }),
+      })),
+      {
+        partialize: state => ({ images: state.images, marks: state.marks }),
+        limit: 50,
+        // A single logical edit (e.g. dragging a point) fires multiple store
+        // actions back-to-back (updateMarkPoint then updateMarkDirty), and
+        // temporal snapshots on every set() call by default -- without this,
+        // one undo only reverts the last of those (the invisible dirty
+        // flag), not the actual edit. Debouncing handleSet coalesces a burst
+        // of same-tick calls into a single history entry.
+        handleSet: handleSet => debounce<typeof handleSet>(handleSet, 300),
+      },
+    ),
     { name: "mark-storage" },
   ),
 );
+
+function debounce<T extends (...args: Parameters<T>) => void>(fn: T, delayMs: number): T {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return ((...args: Parameters<T>) => {
+    if (timer)
+      clearTimeout(timer);
+    timer = setTimeout(fn, delayMs, ...args);
+  }) as T;
+}

--- a/src/stores/mark-store.ts
+++ b/src/stores/mark-store.ts
@@ -127,23 +127,45 @@ export const useMarkStore = create(
         partialize: state => ({ images: state.images, marks: state.marks }),
         limit: 50,
         // A single logical edit (e.g. dragging a point) fires multiple store
-        // actions back-to-back (updateMarkPoint then updateMarkDirty), and
-        // temporal snapshots on every set() call by default -- without this,
-        // one undo only reverts the last of those (the invisible dirty
-        // flag), not the actual edit. Debouncing handleSet coalesces a burst
-        // of same-tick calls into a single history entry.
-        handleSet: handleSet => debounce<typeof handleSet>(handleSet, 300),
+        // actions back-to-back (updateMarkPoint per pointer-move, then
+        // updateMarkDirty), and temporal snapshots on every set() call by
+        // default -- without coalescing, one undo only reverts the last of
+        // those (the invisible dirty flag), not the actual edit.
+        //
+        // This MUST be leading-edge. zundo calls handleSet with the state as
+        // it was *before* that set (see `curriedHandleSet(pastState, ...)` in
+        // zundo/dist/index.js). A trailing-edge debounce keeps the LAST
+        // call's args, i.e. the state just before the final pointer-move --
+        // so undo restored the point to ~where it already was and looked like
+        // a no-op. Leading-edge keeps the FIRST call's args: the state from
+        // before the drag began, which is what undo should restore.
+        handleSet: handleSet => leadingDebounce<typeof handleSet>(handleSet, 300),
       },
     ),
     { name: "mark-storage" },
   ),
 );
 
-function debounce<T extends (...args: Parameters<T>) => void>(fn: T, delayMs: number): T {
+/**
+ * Leading-edge debounce: invokes `fn` immediately on the first call, then
+ * swallows further calls until `delayMs` has elapsed with no calls at all.
+ *
+ * Deliberately leading rather than trailing -- see the handleSet comment
+ * above. A burst of calls therefore yields exactly one invocation, using the
+ * arguments of the call that *started* the burst.
+ */
+function leadingDebounce<T extends (...args: Parameters<T>) => void>(fn: T, delayMs: number): T {
   let timer: ReturnType<typeof setTimeout> | undefined;
   return ((...args: Parameters<T>) => {
+    const isBurstStart = timer === undefined;
+
     if (timer)
       clearTimeout(timer);
-    timer = setTimeout(fn, delayMs, ...args);
+    timer = setTimeout(() => {
+      timer = undefined;
+    }, delayMs);
+
+    if (isBurstStart)
+      fn(...args);
   }) as T;
 }

--- a/src/stores/mark-store.ts
+++ b/src/stores/mark-store.ts
@@ -3,6 +3,7 @@ import { temporal } from "zundo";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
+import { leadingDebounce } from "./store-utils";
 
 export type MarkType = {
   id: string;
@@ -145,27 +146,3 @@ export const useMarkStore = create(
     { name: "mark-storage" },
   ),
 );
-
-/**
- * Leading-edge debounce: invokes `fn` immediately on the first call, then
- * swallows further calls until `delayMs` has elapsed with no calls at all.
- *
- * Deliberately leading rather than trailing -- see the handleSet comment
- * above. A burst of calls therefore yields exactly one invocation, using the
- * arguments of the call that *started* the burst.
- */
-function leadingDebounce<T extends (...args: Parameters<T>) => void>(fn: T, delayMs: number): T {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  return ((...args: Parameters<T>) => {
-    const isBurstStart = timer === undefined;
-
-    if (timer)
-      clearTimeout(timer);
-    timer = setTimeout(() => {
-      timer = undefined;
-    }, delayMs);
-
-    if (isBurstStart)
-      fn(...args);
-  }) as T;
-}

--- a/src/stores/store-utils.ts
+++ b/src/stores/store-utils.ts
@@ -1,0 +1,23 @@
+/**
+ * Leading-edge debounce: invokes `fn` immediately on the first call, then
+ * swallows further calls until `delayMs` has elapsed with no calls at all.
+ *
+ * Deliberately leading rather than trailing -- see the handleSet comment
+ * above. A burst of calls therefore yields exactly one invocation, using the
+ * arguments of the call that *started* the burst.
+ */
+export function leadingDebounce<T extends (...args: Parameters<T>) => void>(fn: T, delayMs: number): T {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return ((...args: Parameters<T>) => {
+    const isBurstStart = timer === undefined;
+
+    if (timer)
+      clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = undefined;
+    }, delayMs);
+
+    if (isBurstStart)
+      fn(...args);
+  }) as T;
+}


### PR DESCRIPTION
## Summary
- Wraps the mark store with `zundo`'s `temporal` middleware, nested as `persist(temporal(immer(...)))` so undo history stays separate from what's persisted to disk
- `Cmd/Ctrl+Z` to undo, `Shift+Cmd/Ctrl+Z` to redo (using the existing cross-platform modifier-key helper), documented in the footer's shortcut tooltip
- Debounces `handleSet` so one point-drag (which fires two store actions — position update, then a dirty-flag update) produces exactly one undo step, not two
- Fixes a related staleness bug: `Mark`'s local `points` React state (needed for live drag feedback) never re-synced when the store changed externally, so an undo would revert the store correctly but the canvas kept rendering the stale pre-undo position
- **Update:** the Atlas (export) canvas now gets the same undo/redo, via the same `zundo` pattern applied to `atlas-store`. `Toolbar.tsx` gained a `position` prop (`"top-left"` default, new `"top-right"`) so a second button group can render per canvas — both canvases now show visible Undo/Redo buttons there (previously keyboard-only). Each canvas's undo history is fully independent (separate `zundo` instances wrapping separate stores) — undoing in one canvas can't affect the other.

## Why
There was no way to recover from a bad point drag except manually dragging it back. Not curve/grid-specific — this benefits plain quad marks too. The Atlas canvas has the identical problem for position/scale/rotation edits on exported textures, so it gets the same fix.

## Test plan
- [x] `tsc --noEmit` / `eslint` clean
- [x] Drag a point, `Cmd+Z`, confirms it reverts to the pre-drag position; `Shift+Cmd+Z` redoes it
- [x] Verified against zundo's actual `handleSet` calling convention (it receives pre-mutation state) with a standalone repro script before landing, since a naive trailing-edge debounce silently restores to the wrong state
- [x] Whole-mark drag and mark creation also produce correct undo steps, not just point drags
- [x] Atlas canvas: move/scale/rotate an exported image, undo/redo via both keyboard and the new toolbar buttons, confirmed working