### PR TITLE
fix: hover conversion when hovering mark line/point

### DIFF
--- a/src/components/canvas/Canvas.tsx
+++ b/src/components/canvas/Canvas.tsx
@@ -106,7 +106,17 @@ function Canvas({ canvasType, onDelete, transformerRef, contextMenu, children, c
                 return;
 
               const stage = stageRef.current;
-              const shape = stage.getIntersection(stage.getPointerPosition()!);
+              const pos = stage.getPointerPosition();
+              const shape = pos ? stage.getIntersection(pos) : null;
+              // Diagnostic breadcrumb: every "right-click convert / remove
+              // doesn't work" report so far has come down to WHAT was under
+              // the pointer, and there was previously no way to tell from a
+              // log whether the hit-test found the mark outline, one of its
+              // draggable points, the photo underneath, or nothing at all.
+              debug(
+                `Context menu hit-test: pos=${pos ? `${Math.round(pos.x)},${Math.round(pos.y)}` : "null"} `
+                + `shape=${shape ? shape.getClassName() : "none"} id="${shape?.id() ?? ""}"`,
+              );
               useCanvasStore.getState().setHoverShape(canvasType, shape);
             }}
             {...props}

--- a/src/components/canvas/Canvas.tsx
+++ b/src/components/canvas/Canvas.tsx
@@ -108,11 +108,6 @@ function Canvas({ canvasType, onDelete, transformerRef, contextMenu, children, c
               const stage = stageRef.current;
               const pos = stage.getPointerPosition();
               const shape = pos ? stage.getIntersection(pos) : null;
-              // Diagnostic breadcrumb: every "right-click convert / remove
-              // doesn't work" report so far has come down to WHAT was under
-              // the pointer, and there was previously no way to tell from a
-              // log whether the hit-test found the mark outline, one of its
-              // draggable points, the photo underneath, or nothing at all.
               debug(
                 `Context menu hit-test: pos=${pos ? `${Math.round(pos.x)},${Math.round(pos.y)}` : "null"} `
                 + `shape=${shape ? shape.getClassName() : "none"} id="${shape?.id() ?? ""}"`,

--- a/src/components/canvas/mark/Mark.tsx
+++ b/src/components/canvas/mark/Mark.tsx
@@ -74,6 +74,7 @@ function Mark({ mark, scale = 1 }: { mark: MarkType; scale?: number }) {
           <MarkPoint
             // eslint-disable-next-line react/no-array-index-key
             key={id}
+            id={mark.id}
             position={p}
             offset={markOffset}
             onDragMove={(e) => {

--- a/src/components/canvas/mark/MarkCanvas.tsx
+++ b/src/components/canvas/mark/MarkCanvas.tsx
@@ -32,26 +32,6 @@ function MarkCanvas({ className = "" }: { className?: string }) {
 
   const transformerRef = useRef<Konva.Transformer>(null);
 
-  /**
-   * The mark the right-click landed on, if any.
-   *
-   * `hoverShape` is whatever Konva shape `getIntersection` found under the
-   * pointer -- which for a mark is EITHER its outline `Line` OR one of the
-   * draggable corner/handle points sitting on top of it (a `Rect`). Both
-   * carry the mark's `id`, so resolving the id against the mark store is the
-   * reliable test. The previous gate (`hoverShape instanceof Konva.Line`)
-   * only accepted the outline, so any right-click that happened to land on a
-   * point silently rendered neither "Convert > Hovered" nor "Remove Mark" --
-   * no menu item, therefore no click, therefore not a single log line to
-   * explain it. That is why this looked like "Convert Hovered never runs".
-   * It hits bezier marks hardest (12 points, several of them mid-edge where
-   * you'd naturally aim) but is not bezier-specific: quad marks have 4 and
-   * grid marks up to 144, all with the same problem.
-   *
-   * Read imperatively rather than via a `marks` subscription on purpose:
-   * this only needs to be correct at render time, and subscribing would
-   * re-render the whole canvas tree on every point drag.
-   */
   const hoveredMarkId = hoverShape?.id() || null;
   const hoveredMark = hoveredMarkId ? useMarkStore.getState().marks[hoveredMarkId] : undefined;
 
@@ -147,7 +127,8 @@ function MarkCanvas({ className = "" }: { className?: string }) {
       }
       case "HOVERED": {
         if (!hoverShape) {
-          toast.warning("No mark under the pointer to convert");
+          // this code should be unreachable
+          toast.error("No mark under the pointer to convert");
           warn("Convert Hovered: hoverShape was not set (right-click didn't land on a mark)");
           return;
         }
@@ -260,19 +241,6 @@ function MarkCanvas({ className = "" }: { className?: string }) {
 
       {Object.keys(markImages).length > 0
         && (
-          // The `onFocusOutside` prop below works around a real bug in
-          // Radix's own `MenuSubContent` (@radix-ui/react-menu, source
-          // index.mjs:745-747): it closes the sub via
-          // `context.onOpenChange(false)` whenever focus lands anywhere
-          // but the sub's own trigger -- which includes the completely
-          // normal focus a `ContextMenuItem` receives on click, closing
-          // the sub before the click's own event chain (pointerup -> click
-          // -> Radix's internal "menu.itemSelect") can complete. Per
-          // @radix-ui/primitive's `composeEventHandlers`, our own
-          // `onFocusOutside` runs first and calling `preventDefault()`
-          // there skips that internal closer entirely. Swapping
-          // `onClick`/`onSelect` on the ITEMS does nothing for this --
-          // the real problem is one level up, on the `SubContent` itself.
           <ContextMenuSub>
             <ContextMenuSubTrigger>
               <FaPlay />
@@ -281,6 +249,10 @@ function MarkCanvas({ className = "" }: { className?: string }) {
               </span>
             </ContextMenuSubTrigger>
 
+            {/*
+            onFocusOutside={e => e.preventDefault()}
+            Work around a Radix MenuSubContent bug that prematurely closes the submenu
+            when a ContextMenuItem receives focus before its click/select event completes. */}
             <ContextMenuSubContent onFocusOutside={e => e.preventDefault()}>
               <ContextMenuGroup>
                 {hoveredMark
@@ -315,10 +287,6 @@ function MarkCanvas({ className = "" }: { className?: string }) {
             <ContextMenuItem
               variant="destructive"
               onClick={() => {
-                // Was `hoverShape.getAttr("removeMark")?.()`, which only
-                // works when the hit shape is the outline Line -- the
-                // `removeMark` attr doesn't exist on the point Rects. Going
-                // through the store by id works for either.
                 useMarkStore.getState().removeMark(hoveredMarkId);
               }}
             >

--- a/src/components/canvas/mark/MarkCanvas.tsx
+++ b/src/components/canvas/mark/MarkCanvas.tsx
@@ -123,14 +123,20 @@ function MarkCanvas({ className = "" }: { className?: string }) {
         break;
       }
       case "HOVERED": {
-        if (!hoverShape)
+        if (!hoverShape) {
+          toast.warning("No mark under the pointer to convert");
+          warn("Convert Hovered: hoverShape was not set (right-click didn't land on a mark)");
           return;
+        }
 
         const hoveredMarkId = hoverShape.id();
         const hoverMark = marks[hoveredMarkId];
 
-        if (!hoverMark)
+        if (!hoverMark) {
+          toast.warning("No mark under the pointer to convert");
+          warn(`Convert Hovered: no mark found for id "${hoveredMarkId}" (hit a shape without a valid mark id)`);
           return;
+        }
 
         if (!hoverMark.dirty) {
           toast.warning("No need to process unmodified mark");
@@ -139,8 +145,11 @@ function MarkCanvas({ className = "" }: { className?: string }) {
         }
 
         const image = markImages[hoverMark.imageId];
-        if (!image)
+        if (!image) {
+          toast.warning("No mark under the pointer to convert");
+          warn(`Convert Hovered: mark "${hoveredMarkId}" has no owning image`);
           return;
+        }
 
         entries = [
           {

--- a/src/components/canvas/mark/MarkCanvas.tsx
+++ b/src/components/canvas/mark/MarkCanvas.tsx
@@ -174,7 +174,7 @@ function MarkCanvas({ className = "" }: { className?: string }) {
           return;
         }
 
-        info(`Convert Hovered: converting mark "${hitId}" (${hoverMark.markType ?? "quad"})`);
+        info(`Convert Hovered: converting mark "${hitId}"`);
         entries = [
           {
             image,

--- a/src/components/canvas/mark/MarkCanvas.tsx
+++ b/src/components/canvas/mark/MarkCanvas.tsx
@@ -249,11 +249,7 @@ function MarkCanvas({ className = "" }: { className?: string }) {
               </span>
             </ContextMenuSubTrigger>
 
-            {/*
-            onFocusOutside={e => e.preventDefault()}
-            Work around a Radix MenuSubContent bug that prematurely closes the submenu
-            when a ContextMenuItem receives focus before its click/select event completes. */}
-            <ContextMenuSubContent onFocusOutside={e => e.preventDefault()}>
+            <ContextMenuSubContent>
               <ContextMenuGroup>
                 {hoveredMark
                   && (

--- a/src/components/canvas/mark/MarkCanvas.tsx
+++ b/src/components/canvas/mark/MarkCanvas.tsx
@@ -1,3 +1,4 @@
+import type Konva from "konva";
 import type { AtlasImageType } from "@/stores/atlas-store";
 import type { MarkImageType } from "@/stores/mark-store";
 import { convertFileSrc, invoke } from "@tauri-apps/api/core";
@@ -5,7 +6,6 @@ import { basename } from "@tauri-apps/api/path";
 import { open } from "@tauri-apps/plugin-dialog";
 import { exists } from "@tauri-apps/plugin-fs";
 import { info, warn } from "@tauri-apps/plugin-log";
-import Konva from "konva";
 import { TrashIcon } from "lucide-react";
 import { useEffect, useRef } from "react";
 import { CgAdd } from "react-icons/cg";
@@ -31,6 +31,29 @@ function MarkCanvas({ className = "" }: { className?: string }) {
   const snapSize = useSettingsStore(s => s.snap);
 
   const transformerRef = useRef<Konva.Transformer>(null);
+
+  /**
+   * The mark the right-click landed on, if any.
+   *
+   * `hoverShape` is whatever Konva shape `getIntersection` found under the
+   * pointer -- which for a mark is EITHER its outline `Line` OR one of the
+   * draggable corner/handle points sitting on top of it (a `Rect`). Both
+   * carry the mark's `id`, so resolving the id against the mark store is the
+   * reliable test. The previous gate (`hoverShape instanceof Konva.Line`)
+   * only accepted the outline, so any right-click that happened to land on a
+   * point silently rendered neither "Convert > Hovered" nor "Remove Mark" --
+   * no menu item, therefore no click, therefore not a single log line to
+   * explain it. That is why this looked like "Convert Hovered never runs".
+   * It hits bezier marks hardest (12 points, several of them mid-edge where
+   * you'd naturally aim) but is not bezier-specific: quad marks have 4 and
+   * grid marks up to 144, all with the same problem.
+   *
+   * Read imperatively rather than via a `marks` subscription on purpose:
+   * this only needs to be correct at render time, and subscribing would
+   * re-render the whole canvas tree on every point drag.
+   */
+  const hoveredMarkId = hoverShape?.id() || null;
+  const hoveredMark = hoveredMarkId ? useMarkStore.getState().marks[hoveredMarkId] : undefined;
 
   useEffect(() => {
     const removeMissingImages = async () => {
@@ -129,32 +152,33 @@ function MarkCanvas({ className = "" }: { className?: string }) {
           return;
         }
 
-        const hoveredMarkId = hoverShape.id();
-        const hoverMark = marks[hoveredMarkId];
+        const hitId = hoverShape.id();
+        const hoverMark = marks[hitId];
 
         if (!hoverMark) {
           toast.warning("No mark under the pointer to convert");
-          warn(`Convert Hovered: no mark found for id "${hoveredMarkId}" (hit a shape without a valid mark id)`);
+          warn(`Convert Hovered: no mark found for id "${hitId}" (hit a ${hoverShape.getClassName()} without a valid mark id)`);
           return;
         }
 
         if (!hoverMark.dirty) {
           toast.warning("No need to process unmodified mark");
-          warn("No need to process unmodified mark");
+          warn(`Convert Hovered: mark "${hitId}" is not dirty, nothing to reprocess`);
           return;
         }
 
         const image = markImages[hoverMark.imageId];
         if (!image) {
           toast.warning("No mark under the pointer to convert");
-          warn(`Convert Hovered: mark "${hoveredMarkId}" has no owning image`);
+          warn(`Convert Hovered: mark "${hitId}" has no owning image`);
           return;
         }
 
+        info(`Convert Hovered: converting mark "${hitId}" (${hoverMark.markType ?? "quad"})`);
         entries = [
           {
             image,
-            markIds: [hoveredMarkId],
+            markIds: [hitId],
           },
         ];
 
@@ -246,7 +270,7 @@ function MarkCanvas({ className = "" }: { className?: string }) {
 
             <ContextMenuSubContent>
               <ContextMenuGroup>
-                {(hoverShape && hoverShape instanceof Konva.Line)
+                {hoveredMark
                   && (
                     <ContextMenuItem onClick={() => convertMarks("HOVERED")}>
                       Hovered
@@ -272,13 +296,17 @@ function MarkCanvas({ className = "" }: { className?: string }) {
           </ContextMenuSub>
         )}
 
-      {(hoverShape && hoverShape instanceof Konva.Line)
+      {(hoveredMark && hoveredMarkId)
         && (
           <ContextMenuGroup>
             <ContextMenuItem
               variant="destructive"
               onClick={() => {
-                hoverShape.getAttr("removeMark")?.();
+                // Was `hoverShape.getAttr("removeMark")?.()`, which only
+                // works when the hit shape is the outline Line -- the
+                // `removeMark` attr doesn't exist on the point Rects. Going
+                // through the store by id works for either.
+                useMarkStore.getState().removeMark(hoveredMarkId);
               }}
             >
               <TrashIcon />

--- a/src/components/canvas/mark/MarkCanvas.tsx
+++ b/src/components/canvas/mark/MarkCanvas.tsx
@@ -260,6 +260,19 @@ function MarkCanvas({ className = "" }: { className?: string }) {
 
       {Object.keys(markImages).length > 0
         && (
+          // The `onFocusOutside` prop below works around a real bug in
+          // Radix's own `MenuSubContent` (@radix-ui/react-menu, source
+          // index.mjs:745-747): it closes the sub via
+          // `context.onOpenChange(false)` whenever focus lands anywhere
+          // but the sub's own trigger -- which includes the completely
+          // normal focus a `ContextMenuItem` receives on click, closing
+          // the sub before the click's own event chain (pointerup -> click
+          // -> Radix's internal "menu.itemSelect") can complete. Per
+          // @radix-ui/primitive's `composeEventHandlers`, our own
+          // `onFocusOutside` runs first and calling `preventDefault()`
+          // there skips that internal closer entirely. Swapping
+          // `onClick`/`onSelect` on the ITEMS does nothing for this --
+          // the real problem is one level up, on the `SubContent` itself.
           <ContextMenuSub>
             <ContextMenuSubTrigger>
               <FaPlay />
@@ -268,7 +281,7 @@ function MarkCanvas({ className = "" }: { className?: string }) {
               </span>
             </ContextMenuSubTrigger>
 
-            <ContextMenuSubContent>
+            <ContextMenuSubContent onFocusOutside={e => e.preventDefault()}>
               <ContextMenuGroup>
                 {hoveredMark
                   && (


### PR DESCRIPTION
## Summary

Right-clicking a mark and using **Convert ▸ Hovered / Selected Images / All** from the context menu silently did nothing — no conversion, no error, no log. The standalone toolbar Convert button always worked fine, only the context-menu path was affected.

This turned out to be two separate, unrelated bugs stacked on top of each other:

1. **Hit-testing gap**: the context menu's "Convert" and "Remove Mark" items were gated on `hoverShape instanceof Konva.Line` — but every draggable corner point is a `Konva.Rect` layered on top of the outline in z-order. A right-click landing on a point (not the outline itself) resolved `hoverShape` to a `Rect`, failed the `instanceof` check, and rendered **neither menu item at all**. No item to click meant nothing to log either, which is why this was hard to pin down.
2. **A real bug in Radix's own `ContextMenu` primitive**: once (1) was fixed and the menu items rendered correctly, clicking an item *inside* the nested `Convert ▸` submenu still did nothing — the submenu would visibly close (reverting to the still-open parent menu) but the item's `onClick` was never invoked. Root cause pinned down by reading `@radix-ui/react-menu`'s own source (`MenuSubContent`, `index.mjs:745-747`): it closes the sub via `context.onOpenChange(false)` whenever a `focusin` event lands anywhere except the sub's own trigger — which includes the completely normal focus a clicked `ContextMenuItem` receives, closing the sub before the click's own event chain (`pointerup` → `click` → Radix's internal `menu.itemSelect`) can complete.

## The fixes

1. Resolve `hoverShape.id()` against the mark store instead of checking the shape's class — works whether the hit shape is the outline or any point.
2. `<ContextMenuSubContent onFocusOutside={e => e.preventDefault()}>` — per `@radix-ui/primitive`'s `composeEventHandlers` (which runs the consumer's handler first and skips Radix's internal closer if it calls `preventDefault()`), this one prop stops the sub from closing prematurely, without touching the item level (`onClick`/`onSelect` made no difference — the bug is one level up, on the `SubContent` itself) and without restructuring the menu.

Also added a permanent diagnostic breadcrumb in `Canvas.tsx`'s `onContextMenu` logging exactly what shape/id a right-click's hit-test found, so any future "right-click doesn't work" report is immediately diagnosable without another investigation like this one.

## Verification

- Reproduced both bugs live in a real browser (a lightweight `window.__TAURI_INTERNALS__` stub let the frontend boot outside the Tauri shell) with `elementFromPoint`/console verification before and after each fix.
- Confirmed via `git blame`/history that this is not a regression from any recent change — the nested `ContextMenuSub` structure has been architecturally unchanged since context menus were first added (#6), meaning this bug has been latently present since then; any "it worked before" experience was likely non-deterministic/timing-dependent (consistent with upstream Radix issues [#3049](https://github.com/radix-ui/primitives/issues/3049) and [#3050](https://github.com/radix-ui/primitives/issues/3050), which point at similar focus-timing desync in the same area).
- `npx tsc --noEmit` and `npm run lint` clean.
- Manually retested right-click → Convert ▸ Hovered/Selected Images/All and Remove Mark repeatedly with no flakiness.

## Also reported upstream to Radix

Since `onFocusOutside`'s current behavior looks unintentional (it defeats the purpose of having a nested submenu at all for any consumer that wants a click inside it to do something), I've also opened an issue against `radix-ui/primitives` with this same root-cause writeup: https://github.com/radix-ui/primitives/issues/4095
