### PR TITLE
feat: add changelog link on update toast

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { Toaster } from "sonner";
 import Footer from "./components/footer/Footer";
 import Navbar from "./components/Navbar";
 import Textract from "./components/Textract";
-import useAutoUpdater from "./hooks/use-auto-updater";
+import useAutoUpdater from "./hooks/UseAutoUpdater";
 import { isShortcutModifierPressed } from "./utils/utils";
 import "./app.css";
 
@@ -28,7 +28,7 @@ function App() {
         closeButton
         swipeDirections={["left"]}
         toastOptions={{
-          style: { width: "fit-content" },
+          style: { minWidth: "280px", maxWidth: "320px" },
         }}
 
       />

--- a/src/hooks/UseAutoUpdater.tsx
+++ b/src/hooks/UseAutoUpdater.tsx
@@ -15,8 +15,18 @@ export default function useAutoUpdater() {
       if (!update)
         return;
 
-      toast.info(`New Update Available`, {
+      toast.info("Update Available", {
         duration: 10000,
+        description: (
+          <a
+            href="https://github.com/simonsanchezart/textract/releases/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            View changelog
+          </a>
+        ),
         action: {
           label: "Install Update",
           onClick: async () => {


### PR DESCRIPTION
<img width="338" height="91" alt="textract_QuHKg1lwSe" src="https://github.com/user-attachments/assets/6bbd199b-0bc8-4df3-823f-be2b565c76de" />

Adds a link to the [Releases](https://github.com/simonsanchezart/textract/releases/) page, so the user can see the changelogs before deciding to update.

It doesn't link to just the latest update, as there might have been multiple releases (therefore, multiple changelogs) since the user's current version.