### PR TITLE
fix: apply EXIF orientation when decoding images

### DIFF
--- a/src-tauri/src/transformation.rs
+++ b/src-tauri/src/transformation.rs
@@ -1,5 +1,6 @@
 use base64::{engine::general_purpose, Engine};
-use image::{open, RgbaImage};
+use image::metadata::Orientation;
+use image::{DynamicImage, ImageDecoder, ImageReader, RgbaImage};
 use imageproc::geometric_transformations::{warp_into, Interpolation, Projection};
 use rayon::{
     iter::{IndexedParallelIterator, ParallelIterator},
@@ -12,7 +13,7 @@ pub async fn transform_image(img_path: String, points: Vec<f32>) -> Result<Vec<S
     let mark_count = points.len() / 8;
     log::info!("Processing {mark_count} marks for {img_path}");
 
-    let img = open(&img_path).unwrap().to_rgba8();
+    let img = open_image_with_orientation(&img_path)?;
     let img_name = crate::utils::get_filename_or_invalid(&img_path);
 
     let buffers: Result<Vec<String>, String> = points
@@ -50,6 +51,17 @@ pub async fn transform_image(img_path: String, points: Vec<f32>) -> Result<Vec<S
 
     log::info!("Finished processing all marks for {}", img_name);
     buffers
+}
+
+/// Opens an image with its EXIF orientation applied, so pixel coordinates
+/// match what the frontend renders (the browser honors EXIF when displaying).
+fn open_image_with_orientation(img_path: &str) -> Result<RgbaImage, String> {
+    let reader = ImageReader::open(img_path).map_err(|e| e.to_string())?;
+    let mut decoder = reader.into_decoder().map_err(|e| e.to_string())?;
+    let orientation = decoder.orientation().unwrap_or(Orientation::NoTransforms);
+    let mut img = DynamicImage::from_decoder(decoder).map_err(|e| e.to_string())?;
+    img.apply_orientation(orientation);
+    Ok(img.to_rgba8())
 }
 
 fn get_quad_dimensions(points: &[(f32, f32); 4]) -> (f32, f32) {


### PR DESCRIPTION
## Problem

Extracting a texture from a photo that has EXIF orientation metadata (e.g. `Rotate 90 CW` / orientation 6 — very common on iPhone photos) produces a completely unrelated region of the image instead of the marked quad.

## Root cause

The frontend renders the image through the browser (`<img>` / HTML Image), which honors EXIF orientation and displays the photo already rotated. Corner coordinates are therefore picked in the *rotated* space.

The backend (`transform_image`) decodes the same file with `image::open()`, which returns the *raw, unrotated* pixel buffer. The picked coordinates are then applied directly to that raw buffer, so they land on a different part of the image — for a 90° rotation the mismatch is total.

Example from a real photo (5712×4284 raw, orientation 6 → displayed as 4284×5712):

```
Source: [(438.0, 4088.0), (3584.0, 4126.0), (3881.0, 4499.0), (35.0, 4428.0)]
```

The y values up to 4499 only make sense in the rotated (5712-tall) frame — they exceed the raw image height.

## Fix

Decode the image with `ImageReader` and apply the decoder-reported EXIF orientation via `DynamicImage::apply_orientation`, so the backend pixel coordinates match what the frontend renders. `transform_image` behavior is otherwise unchanged.

## Testing

- `cargo check` passes.
- Built and verified on macOS (arm64): marking corners on an orientation-6 iPhone photo now extracts the correct region.

## Notes

- Only `src-tauri/src/transformation.rs` is touched.
